### PR TITLE
Persisted AudioContext for priming Web Audio engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
    - Quirks: in continuous mode, calling `stop` in-between `recognizing` and `recognized` will not emit final `result` event
 - Speech recognition: New `audioConfig` option to override the default `AudioConfig.fromDefaultMicrophoneInput`, in PR [#33](https://github.com/compulim/web-speech-cognitive-services/pull/33)
 - Speech synthesis: Fix [#32](https://github.com/compulim/web-speech-cognitive-services/issues/32), fetch voices from services, in PR [#35](https://github.com/compulim/web-speech-cognitive-services/pull/35)
-- Speech synthesis: Fix [#34](https://github.com/compulim/web-speech-cognitive-services/issues/34), in PR [#XXX](https://github.com/compulim/web-speech-cognitive-services/pull/XXX)
+- Speech synthesis: Fix [#34](https://github.com/compulim/web-speech-cognitive-services/issues/34), in PR [#36](https://github.com/compulim/web-speech-cognitive-services/pull/36)
    - Support user-controlled `AudioContext` object to be passed as an option named `audioContext`
    - If no `audioContext` option is passed, will create a new `AudioContext` object and permanently allocated
-- Speech synthesis: If an empty utterance is being synthesized, will play an empty local audio clip instead, in PR [#XXX](https://github.com/compulim/web-speech-cognitive-services/pull/XXX)
+- Speech synthesis: If an empty utterance is being synthesized, will play an empty local audio clip instead, in PR [#36](https://github.com/compulim/web-speech-cognitive-services/pull/36)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,25 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Breaking changes
+
+- Instead of stopping `AudioContext` after all utterances are finished, the `AudioContext` is now permanently allocated. If this is not desirable in your application, please create your own `AudioContext` instance and pass it as an option named `audioContext` when creating the ponyfill
+
 ### Added
+
 - Speech recognition: Fix [#23](https://github.com/compulim/web-speech-cognitive-services/issues/23) and [#24](https://github.com/compulim/web-speech-cognitive-services/issues/24), support `audiostart`/`audioend`/`soundstart`/`soundend` event, in PR [#33](https://github.com/compulim/web-speech-cognitive-services/pull/33)
 - Speech recognition: Fix [#25](https://github.com/compulim/web-speech-cognitive-services/issues/25) and [#26](https://github.com/compulim/web-speech-cognitive-services/issues/26), support true `abort` and `stop` function, in PR [#33](https://github.com/compulim/web-speech-cognitive-services/pull/33)
 - Speech recognition: Fix [#29](https://github.com/compulim/web-speech-cognitive-services/issues/29), support continuous mode, in PR [#33](https://github.com/compulim/web-speech-cognitive-services/pull/33)
    - Quirks: in continuous mode, calling `stop` in-between `recognizing` and `recognized` will not emit final `result` event
 - Speech recognition: New `audioConfig` option to override the default `AudioConfig.fromDefaultMicrophoneInput`, in PR [#33](https://github.com/compulim/web-speech-cognitive-services/pull/33)
-- Speech synthesis: Fix [#32](https://github.com/compulim/web-speech-cognitive-services/issues/29), fetch voices from services, in PR [#35](https://github.com/compulim/web-speech-cognitive-services/pull/35)
+- Speech synthesis: Fix [#32](https://github.com/compulim/web-speech-cognitive-services/issues/32), fetch voices from services, in PR [#35](https://github.com/compulim/web-speech-cognitive-services/pull/35)
+- Speech synthesis: Fix [#34](https://github.com/compulim/web-speech-cognitive-services/issues/34), in PR [#XXX](https://github.com/compulim/web-speech-cognitive-services/pull/XXX)
+   - Support user-controlled `AudioContext` object to be passed as an option named `audioContext`
+   - If no `audioContext` option is passed, will create a new `AudioContext` object and permanently allocated
+- Speech synthesis: If an empty utterance is being synthesized, will play an empty local audio clip instead, in PR [#XXX](https://github.com/compulim/web-speech-cognitive-services/pull/XXX)
 
 ### Changed
+
 - Bumped dependencies, in PR [#20](https://github.com/compulim/web-speech-cognitive-services/pull/20)
    - [@babel/cli@^7.5.5](https://www.npmjs.com/package/@babel/cli)
    - [@babel/core@^7.5.5](https://www.npmjs.com/package/@babel/core)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Speech synthesis: Fix [#32](https://github.com/compulim/web-speech-cognitive-services/issues/32), fetch voices from services, in PR [#35](https://github.com/compulim/web-speech-cognitive-services/pull/35)
 - Speech synthesis: Fix [#34](https://github.com/compulim/web-speech-cognitive-services/issues/34), in PR [#36](https://github.com/compulim/web-speech-cognitive-services/pull/36)
    - Support user-controlled `AudioContext` object to be passed as an option named `audioContext`
-   - If no `audioContext` option is passed, will create a new `AudioContext` object and permanently allocated
+   - If no `audioContext` option is passed, will create a new `AudioContext` object
 - Speech synthesis: If an empty utterance is being synthesized, will play an empty local audio clip instead, in PR [#36](https://github.com/compulim/web-speech-cognitive-services/pull/36)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Breaking changes
 
-- Instead of stopping `AudioContext` after all utterances are finished, the `AudioContext` is now permanently allocated. If this is not desirable in your application, please create your own `AudioContext` instance and pass it as an option named `audioContext` when creating the ponyfill
+- Instead of stopping `AudioContext` after all pending utterances are finished, the `AudioContext` is now persisted. If this is not desirable in your application and would like to control the lifetime of `AudioContext` object, please create your own instance and pass it as an option named `audioContext` when creating the ponyfill
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Speech synthesis: Fix [#34](https://github.com/compulim/web-speech-cognitive-services/issues/34), in PR [#36](https://github.com/compulim/web-speech-cognitive-services/pull/36)
    - Support user-controlled `AudioContext` object to be passed as an option named `audioContext`
    - If no `audioContext` option is passed, will create a new `AudioContext` object
-- Speech synthesis: If an empty utterance is being synthesized, will play an empty local audio clip instead, in PR [#36](https://github.com/compulim/web-speech-cognitive-services/pull/36)
+- Speech synthesis: If an empty utterance is being synthesized, will play an local empty audio clip, in PR [#36](https://github.com/compulim/web-speech-cognitive-services/pull/36)
 
 ### Changed
 

--- a/packages/component/package-lock.json
+++ b/packages/component/package-lock.json
@@ -2599,6 +2599,11 @@
 				}
 			}
 		},
+		"base64-arraybuffer": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
+			"integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ=="
+		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -68,6 +68,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.5.5",
+    "base64-arraybuffer": "^0.2.0",
     "event-as-promise": "^1.0.5",
     "events": "^3.0.0",
     "memoize-one": "^5.0.5",

--- a/packages/component/src/SpeechServices/TextToSpeech/AudioContextConsumer.js
+++ b/packages/component/src/SpeechServices/TextToSpeech/AudioContextConsumer.js
@@ -1,4 +1,8 @@
 export default class {
+  constructor(audioContext) {
+    this.audioContext = audioContext;
+  }
+
   pause() {
     this.audioContext && this.audioContext.suspend();
     this.playingUtterance && this.playingUtterance.emit('pause');
@@ -9,37 +13,28 @@ export default class {
     this.playingUtterance && this.playingUtterance.emit('resume');
   }
 
-  async start(queue, { AudioContext }) {
-    if (this.audioContext) {
-      throw new Error('already started');
-    }
-
+  async start(queue) {
     let utterance;
 
-    try {
-      while ((utterance = queue.shift())) {
-        this.playingUtterance = utterance;
+    while ((utterance = queue.shift())) {
+      this.playingUtterance = utterance;
 
-        await utterance.play(this.audioContext || (this.audioContext = new AudioContext()));
+      await utterance.play(this.audioContext);
 
-        this.playingUtterance = null;
-      }
-    } finally {
-      await this.audioContext && this.audioContext.close();
+      this.playingUtterance = null;
     }
   }
 
   stop() {
     this.playingUtterance && this.playingUtterance.stop();
 
-    if (this.audioContext) {
+    if (this.audioContext.state === 'suspended') {
       // Play -> Pause -> Cancel (stop)
       // This would generate these events: "start", "pause", "end"
 
       // Without this code, the "end" event will not emit until resume() is called
       // Cancelling an unstarted utterance will not emit any "start" or "end" event
-      this.audioContext.close();
-      this.audioContext = null;
+      this.audioContext.resume();
     }
   }
 }

--- a/packages/component/src/SpeechServices/TextToSpeech/AudioContextQueue.js
+++ b/packages/component/src/SpeechServices/TextToSpeech/AudioContextQueue.js
@@ -1,10 +1,10 @@
 import AudioContextConsumer from './AudioContextConsumer';
 
 export default class {
-  constructor(ponyfill) {
+  constructor({ audioContext, ponyfill }) {
+    this.audioContext = audioContext || new ponyfill.AudioContext();
     this.consumer = null;
     this.paused = false;
-    this.ponyfill = ponyfill;
     this.queue = [];
   }
 
@@ -33,9 +33,13 @@ export default class {
   }
 
   async startConsumer() {
+    const { audioContext } = this;
+
     while (!this.paused && this.queue.length && !this.consumer) {
-      this.consumer = new AudioContextConsumer();
-      await this.consumer.start(this.queue, this.ponyfill);
+      this.consumer = new AudioContextConsumer(audioContext);
+
+      await this.consumer.start(this.queue);
+
       this.consumer = null;
     }
   }

--- a/packages/component/src/SpeechServices/TextToSpeech/createSpeechSynthesisPonyfill.js
+++ b/packages/component/src/SpeechServices/TextToSpeech/createSpeechSynthesisPonyfill.js
@@ -13,6 +13,7 @@ const TOKEN_EXPIRATION = 600000;
 const TOKEN_EARLY_RENEWAL = 60000;
 
 export default async ({
+  audioContext,
   authorizationToken,
   ponyfill = {
     AudioContext: window.AudioContext || window.webkitAudioContext
@@ -56,7 +57,7 @@ export default async ({
       super(['voiceschanged']);
 
       this.outputFormat = DEFAULT_OUTPUT_FORMAT;
-      this.queue = new AudioContextQueue(ponyfill);
+      this.queue = new AudioContextQueue({ audioContext, ponyfill });
       this.voices = [];
 
       this.updateVoices();

--- a/packages/component/src/SpeechServices/TextToSpeech/fetchSpeechData.js
+++ b/packages/component/src/SpeechServices/TextToSpeech/fetchSpeechData.js
@@ -1,7 +1,9 @@
+import { decode } from 'base64-arraybuffer';
 import buildSSML from './buildSSML';
 
 const DEFAULT_LANGUAGE = 'en-US';
 const DEFAULT_VOICE = 'Microsoft Server Speech Text to Speech Voice (en-US, JessaRUS)'
+const EMPTY_MP3_BASE64 = 'SUQzBAAAAAAAI1RTU0UAAAAPAAADTGF2ZjU3LjU2LjEwMQAAAAAAAAAAAAAA//tAwAAAAAAAAAAAAAAAAAAAAAAASW5mbwAAAA8AAAACAAABhgC7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7//////////////////////////////////////////////////////////////////8AAAAATGF2YzU3LjY0AAAAAAAAAAAAAAAAJAUHAAAAAAAAAYYoRBqpAAAAAAD/+xDEAAPAAAGkAAAAIAAANIAAAARMQU1FMy45OS41VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVf/7EMQpg8AAAaQAAAAgAAA0gAAABFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV';
 const SYNTHESIS_URL_TEMPLATE = 'https://{region}.tts.speech.microsoft.com/cognitiveservices/v1';
 
 export default async function ({
@@ -15,8 +17,15 @@ export default async function ({
   voice = DEFAULT_VOICE,
   volume
 }) {
+  if (!text) {
+    // If text is empty, play a short audio clip. This allows developers to easily prime the AudioContext object by playing an empty string.
+    return decode(EMPTY_MP3_BASE64);
+  }
+
   const ssml = buildSSML({ lang, pitch, rate, text, voice, volume });
-  const url = SYNTHESIS_URL_TEMPLATE.replace(/\{region\}/, region);
+
+  // Although calling encodeURI on hostname does not actually works, it fails faster and safer.
+  const url = SYNTHESIS_URL_TEMPLATE.replace(/\{region\}/, encodeURI(region));
 
   const res = await fetch(url, {
     headers: {


### PR DESCRIPTION
> Fix #34.

## Description

Before playing audio clips, on Safari, the `play()` function on that specific `AudioContext` instance, need to explicitly triggered by user gesture.

This work will enable persisted `AudioContext` object, or passable thru options. Developers can prime the `AudioContext` object by either pronouncing an empty string, or pass in a pre-primed `AudioContext` object.

## Changelog

### Breaking changes

- Instead of stopping `AudioContext` after all pending utterances are finished, the `AudioContext` is now persisted. If this is not desirable in your application and would like to control the lifetime of `AudioContext` object, please create your own instance and pass it as an option named `audioContext` when creating the ponyfill

### Added

- Speech synthesis: Fix [#34](https://github.com/compulim/web-speech-cognitive-services/issues/34), in PR [#36](https://github.com/compulim/web-speech-cognitive-services/pull/36)
   - Support user-controlled `AudioContext` object to be passed as an option named `audioContext`
   - If no `audioContext` option is passed, will create a new `AudioContext` object and permanently allocated
- Speech synthesis: If an empty utterance is being synthesized, will play an empty local audio clip instead, in PR [#36](https://github.com/compulim/web-speech-cognitive-services/pull/36)
