### PR TITLE
Support custom speech and custom voice font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
    - Pass it as an array to `SpeechRecognition.grammars.phrases`
 - Speech recognition: Fix [#31](https://github.com/compulim/web-speech-cognitive-services/issues/31), support reference grammars, in PR [#37](https://github.com/compulim/web-speech-cognitive-services/pull/37)
    - When creating the ponyfill, pass it as an array to `referenceGrammars` options
+- Speech recognition: Fix [#27](https://github.com/compulim/web-speech-cognitive-services/issues/27), support custom speech, in PR [#XXX](https://github.com/compulim/web-speech-cognitive-services/pull/XXX)
+   - Use option `speechRecognitionEndpointId`
+- Speech synthesis: Fix [#28](https://github.com/compulim/web-speech-cognitive-services/issues/28), support custom voice font, in PR [#XXX](https://github.com/compulim/web-speech-cognitive-services/pull/XXX)
+   - Use option `speechSynthesisDeploymentId`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
    - Pass it as an array to `SpeechRecognition.grammars.phrases`
 - Speech recognition: Fix [#31](https://github.com/compulim/web-speech-cognitive-services/issues/31), support reference grammars, in PR [#37](https://github.com/compulim/web-speech-cognitive-services/pull/37)
    - When creating the ponyfill, pass it as an array to `referenceGrammars` options
-- Speech recognition: Fix [#27](https://github.com/compulim/web-speech-cognitive-services/issues/27), support custom speech, in PR [#XXX](https://github.com/compulim/web-speech-cognitive-services/pull/XXX)
+- Speech recognition: Fix [#27](https://github.com/compulim/web-speech-cognitive-services/issues/27), support custom speech, in PR [#41](https://github.com/compulim/web-speech-cognitive-services/pull/41)
    - Use option `speechRecognitionEndpointId`
-- Speech synthesis: Fix [#28](https://github.com/compulim/web-speech-cognitive-services/issues/28), support custom voice font, in PR [#XXX](https://github.com/compulim/web-speech-cognitive-services/pull/XXX)
+- Speech synthesis: Fix [#28](https://github.com/compulim/web-speech-cognitive-services/issues/28), support custom voice font, in PR [#41](https://github.com/compulim/web-speech-cognitive-services/pull/41)
    - Use option `speechSynthesisDeploymentId`
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ In the sample below, we use the bundle to perform text-to-speech with a voice na
 </html>
 ```
 
-> Since we do not host the bundle, you should always use [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) to protect its integrity when loading from a third-party CDN.
+> We do not host the bundle. You should always use [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) to protect bundle integrity when loading from a third-party CDN.
 
 ## Install from NPM
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,54 @@ Microsoft Azure [Cognitive Services Speech Services](https://azure.microsoft.com
 
 This package will polyfill Web Speech API by turning Cognitive Services Speech Services API into Web Speech API. We test this package with popular combination of platforms and browsers.
 
+## Browser requirements
+
+Speech recognition requires WebRTC API and the page must hosted thru HTTPS or `localhost`. Although iOS 12 support WebRTC, native apps using `WKWebView` do not support WebRTC.
+
+Speech synthesis requires Web Audio API. For Safari, user gesture (click or tap) is required to play audio clips using Web Audio API. To ready the Web Audio API to use without user gesture, you can synthesize an empty string.
+
 # How to use
+
+There are two ways to use this package:
+
+1. [Using `<script>` to load the bundle](#using-script-to-load-the-bundle)
+1. [Install from NPM](#install-from-npm)
+
+## Using `<script>` to load the bundle
+
+To use the ponyfill directly in HTML, you can use our published bundle from unpkg.
+
+In the sample below, we use the bundle to perform text-to-speech with a voice named "JessaRUS".
+
+```html
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <script src="https://unpkg.com/web-speech-cognitive-services/umd/web-speech-cognitive-services.production.min.js"></script>
+  </head>
+  <body>
+    <script>
+      const { speechSynthesis, SpeechSynthesisUtterance } = window.WebSpeechCognitiveServices.create({
+        region: 'westus2',
+        subscriptionKey: 'YOUR_SUBSCRIPTION_KEY'
+      });
+
+      speechSynthesis.addEventListener('voiceschanged', () => {
+        const voices = speechSynthesis.getVoices();
+        const utterance = new SpeechSynthesisUtterance('Hello, World!');
+
+        utterance.voice = voices.find(voice => /JessaRUS/u.test(voice.name));
+
+        speechSynthesis.speak(utterance);
+      });
+    </script>
+  </body>
+</html>
+```
+
+> Since we do not host the bundle, you should always use [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) to protect its integrity when loading from a third-party CDN.
+
+## Install from NPM
 
 For production build, run `npm install web-speech-cognitive-services`.
 
@@ -38,56 +85,7 @@ In this package, we prefer ponyfill because it do not pollute the hosting enviro
 
 > For readability, we omitted the async function in all code snippets. To run the code, you will need to wrap the code using an async function.
 
-## Polyfilling the environment
-
-If the library you are using do not support ponyfill, you can polyfill `window` object with our ponyfill.
-
-```jsx
-import createPonyfill from 'web-speech-cognitive-services/lib/SpeechServices';
-
-const ponyfill = await createPonyfill({
-  region: 'westus',
-  subscriptionKey: 'YOUR_SUBSCRIPTION_KEY'
-});
-
-for (let key in ponyfill) {
-  window[key] = ponyfill[key];
-}
-```
-
-> Note: if you do not specify `region`, we will default to `"westus"`.
-
-> List of supported regions can be found in [this article](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/rest-apis#regions-and-endpoints).
-
-> If you prefer to use the deprecating Bing Speech, import from `'web-speech-cognitive-services/lib/BingSpeech'` instead.
-
-## Using authorization token
-
-Instead of exposing subscription key on the browser, we strongly recommend using authorization token.
-
-```jsx
-import createPonyfill from 'web-speech-cognitive-services/lib/SpeechServices';
-
-const ponyfill = await createPonyfill({
-  authorizationToken: 'YOUR_AUTHORIZATION_TOKEN',
-  region: 'westus',
-});
-```
-
-You can also provide an async function that will fetch the authorization token on-demand. You should cache the authorization token for subsequent request.
-
-```jsx
-import createPonyfill from 'web-speech-cognitive-services/lib/SpeechServices';
-
-const ponyfill = await createPonyfill({
-  authorizationToken: fetch('https://example.com/your-token').then(res => res.text()),
-  region: 'westus',
-});
-```
-
 ## Speech recognition (speech-to-text)
-
-You can choose to only create ponyfill for speech recognition.
 
 ```jsx
 import { createSpeechRecognitionPonyfill } from 'web-speech-cognitive-services/lib/SpeechServices/SpeechToText';
@@ -185,9 +183,14 @@ const {
   subscriptionKey: 'YOUR_SUBSCRIPTION_KEY'
 });
 
-const utterance = new SpeechSynthesisUtterance('Hello, World!');
+speechSynthesis.addEventListener('voiceschanged', () => {
+  const voices = speechSynthesis.getVoices();
+  const utterance = new SpeechSynthesisUtterance('Hello, World!');
 
-await speechSynthesis.speak(utterance);
+  utterance.voice = voices.find(voice => /JessaRUS/u.test(voice.name));
+
+  speechSynthesis.speak(utterance);
+});
 ```
 
 > Note: `speechSynthesis` is camel-casing because it is an instance.
@@ -237,6 +240,36 @@ export default class extends React.Component {
   }
 }
 ```
+
+## Using authorization token
+
+Instead of exposing subscription key on the browser, we strongly recommend using authorization token.
+
+```jsx
+import createPonyfill from 'web-speech-cognitive-services/lib/SpeechServices';
+
+const ponyfill = await createPonyfill({
+  authorizationToken: 'YOUR_AUTHORIZATION_TOKEN',
+  region: 'westus',
+});
+```
+
+You can also provide an async function that will fetch the authorization token on-demand. You should cache the authorization token for subsequent request.
+
+```jsx
+import createPonyfill from 'web-speech-cognitive-services/lib/SpeechServices';
+
+const ponyfill = await createPonyfill({
+  authorizationToken: fetch('https://example.com/your-token').then(res => res.text()),
+  region: 'westus',
+});
+```
+
+> Note: if you do not specify `region`, we will default to `"westus"`.
+
+> List of supported regions can be found in [this article](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/rest-apis#regions-and-endpoints).
+
+> If you prefer to use the deprecating Bing Speech, import from `'web-speech-cognitive-services/lib/BingSpeech'` instead.
 
 ## Lexical and ITN support
 
@@ -296,6 +329,7 @@ For detailed test matrix, please refer to [`SPEC-RECOGNITION.md`](SPEC-RECOGNITI
    * Continuous mode does not work
 * Speech synthesis
    * `onboundary`, `onmark`, `onpause`, and `onresume` are not supported/fired
+   * `pause` will pause immediately and do not pause on word breaks
 
 ## Quirks
 

--- a/README.md
+++ b/README.md
@@ -242,6 +242,46 @@ export default class extends React.Component {
 
 [Lexical and ITN support](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/rest-apis#response-parameters) is unique in Cognitive Services Speech Services. Our adapter added additional properties `transcriptITN`, `transcriptLexical`, and `transcriptMaskedITN` to surface the result, in addition to `transcript` and `confidence`.
 
+## Custom Speech support
+
+> Please refer to ["What is Custom Speech?"](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/how-to-custom-speech) for tutorial on creating your first Custom Speech model.
+
+To use custom speech for speech recognition, you need to pass the endpoint ID while creating the ponyfill.
+
+```js
+import createPonyfill from 'web-speech-cognitive-services/lib/SpeechServices';
+
+const ponyfill = await createPonyfill({
+  region: 'westus',
+  speechRecognitionEndpointId: '12345678-1234-5678-abcd-12345678abcd',
+  subscriptionKey: 'YOUR_SUBSCRIPTION_KEY'
+});
+```
+
+## Custom Voice support
+
+> Please refer to ["Get started with Custom Voice"](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/how-to-custom-voice) for tutorial on creating your first Custom Voice model.
+
+To use Custom Voice for speech synthesis, you need to pass the deployment ID while creating the ponyfill, and pass the voice model name as voice URI.
+
+```js
+import createPonyfill from 'web-speech-cognitive-services/lib/SpeechServices';
+
+const ponyfill = await createPonyfill({
+  region: 'westus',
+  speechSynthesisDeploymentId: '12345678-1234-5678-abcd-12345678abcd',
+  subscriptionKey: 'YOUR_SUBSCRIPTION_KEY'
+});
+
+const { speechSynthesis, SpeechSynthesisUtterance } = ponyfill;
+
+const utterance = new SpeechSynthesisUtterance('Hello, World!');
+
+utterance.voice = { voiceURI: 'your-model-name' };
+
+await speechSynthesis.speak(utterance);
+```
+
 # Test matrix
 
 For detailed test matrix, please refer to [`SPEC-RECOGNITION.md`](SPEC-RECOGNITION.md) or [`SPEC-SYNTHESIS.md`](SPEC-SYNTHESIS.md).
@@ -274,12 +314,12 @@ For detailed test matrix, please refer to [`SPEC-RECOGNITION.md`](SPEC-RECOGNITI
    * [x] Add continuous mode
    * [ ] Investigate support of Opus (OGG) encoding
       * Currently, there is a problem with `microsoft-speech-browser-sdk@0.0.12`, tracking on [this issue](https://github.com/Azure-Samples/SpeechToText-WebSockets-Javascript/issues/88)
-   * [ ] Support custom speech
+   * [x] Support custom speech
    * [x] Support ITN, masked ITN, and lexical output
 * Speech synthesis
    * [x] Event: add `pause`/`resume` support
    * [x] Properties: add `paused`/`pending`/`speaking` support
-   * [ ] Support [custom voice fonts](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/rest-apis#text-to-speech-api)
+   * [x] Support [custom voice fonts](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/rest-apis#text-to-speech-api)
 
 # Contributions
 

--- a/packages/component/src/SpeechServices/SpeechToText/createSpeechRecognitionPonyfill.js
+++ b/packages/component/src/SpeechServices/SpeechToText/createSpeechRecognitionPonyfill.js
@@ -77,6 +77,7 @@ export default ({
   authorizationToken,
   referenceGrammars,
   region = 'westus',
+  speechRecognitionEndpointId,
   subscriptionKey,
   textNormalization = 'display'
 } = {}) => {
@@ -119,6 +120,10 @@ export default ({
         SpeechConfig.fromAuthorizationToken(typeof authorizationToken === 'function' ? await authorizationToken() : await authorizationToken, region)
       :
         SpeechConfig.fromSubscription(subscriptionKey, region);
+
+      if (speechRecognitionEndpointId) {
+        speechConfig.endpointId = speechRecognitionEndpointId;
+      }
 
       speechConfig.outputFormat = OutputFormat.Detailed;
       speechConfig.speechRecognitionLanguage = this.lang || 'en-US';

--- a/packages/component/src/SpeechServices/SpeechToText/createSpeechRecognitionPonyfill.test.js
+++ b/packages/component/src/SpeechServices/SpeechToText/createSpeechRecognitionPonyfill.test.js
@@ -1171,8 +1171,6 @@ describe('SpeechRecognition with text normalization', () => {
 });
 
 describe('SpeechRecognition with Custom Speech', () => {
-  let speechRecognition;
-
   test('should set up SpeechConfig with endpoint ID', async () => {
     const { default: createSpeechRecognitionPonyfill } = require('./createSpeechRecognitionPonyfill');
     const { SpeechRecognition } = createSpeechRecognitionPonyfill({
@@ -1181,7 +1179,8 @@ describe('SpeechRecognition with Custom Speech', () => {
       subscriptionKey: 'SUBSCRIPTION_KEY'
     });
 
-    speechRecognition = new SpeechRecognition();
+    const speechRecognition = new SpeechRecognition();
+
     speechRecognition.start();
 
     expect(recognizer.speechConfig).toHaveProperty('endpointId', '12345678-1234-5678-abcd-12345678abcd');

--- a/packages/component/src/SpeechServices/SpeechToText/createSpeechRecognitionPonyfill.test.js
+++ b/packages/component/src/SpeechServices/SpeechToText/createSpeechRecognitionPonyfill.test.js
@@ -235,7 +235,7 @@ describe('SpeechRecognition', () => {
 
   beforeEach(async () => {
     const { default: createSpeechRecognitionPonyfill } = require('./createSpeechRecognitionPonyfill');
-    const { SpeechRecognition } = await createSpeechRecognitionPonyfill({
+    const { SpeechRecognition } = createSpeechRecognitionPonyfill({
       region: 'westus',
       subscriptionKey: 'SUBSCRIPTION_KEY'
     });
@@ -949,7 +949,7 @@ describe('SpeechRecognition', () => {
 
   test('with dynamic grammars', async () => {
     const { default: createSpeechRecognitionPonyfill } = require('./createSpeechRecognitionPonyfill');
-    const { SpeechRecognition } = await createSpeechRecognitionPonyfill({
+    const { SpeechRecognition } = createSpeechRecognitionPonyfill({
       region: 'westus',
       subscriptionKey: 'SUBSCRIPTION_KEY',
       textNormalization: 'maskeditn'
@@ -968,7 +968,7 @@ describe('SpeechRecognition', () => {
 
   test('with reference grammars', async () => {
     const { default: createSpeechRecognitionPonyfill } = require('./createSpeechRecognitionPonyfill');
-    const { SpeechRecognition } = await createSpeechRecognitionPonyfill({
+    const { SpeechRecognition } = createSpeechRecognitionPonyfill({
       referenceGrammars: ['12345678-1234-5678-abcd-12345678abcd'],
       region: 'westus',
       subscriptionKey: 'SUBSCRIPTION_KEY',
@@ -986,7 +986,7 @@ describe('SpeechRecognition', () => {
 
   test('with new SpeechGrammarList', async () => {
     const { default: createSpeechRecognitionPonyfill } = require('./createSpeechRecognitionPonyfill');
-    const { SpeechGrammarList, SpeechRecognition } = await createSpeechRecognitionPonyfill({
+    const { SpeechGrammarList, SpeechRecognition } = createSpeechRecognitionPonyfill({
       region: 'westus',
       subscriptionKey: 'SUBSCRIPTION_KEY',
       textNormalization: 'maskeditn'
@@ -1021,7 +1021,7 @@ describe('SpeechRecognition with text normalization', () => {
 
   test('of ITN should result in ITN', async () => {
     const { default: createSpeechRecognitionPonyfill } = require('./createSpeechRecognitionPonyfill');
-    const { SpeechRecognition } = await createSpeechRecognitionPonyfill({
+    const { SpeechRecognition } = createSpeechRecognitionPonyfill({
       region: 'westus',
       subscriptionKey: 'SUBSCRIPTION_KEY',
       textNormalization: 'itn'
@@ -1071,7 +1071,7 @@ describe('SpeechRecognition with text normalization', () => {
 
   test('of lexical should result in lexical', async () => {
     const { default: createSpeechRecognitionPonyfill } = require('./createSpeechRecognitionPonyfill');
-    const { SpeechRecognition } = await createSpeechRecognitionPonyfill({
+    const { SpeechRecognition } = createSpeechRecognitionPonyfill({
       region: 'westus',
       subscriptionKey: 'SUBSCRIPTION_KEY',
       textNormalization: 'lexical'
@@ -1121,7 +1121,7 @@ describe('SpeechRecognition with text normalization', () => {
 
   test('of masked ITN should result in masked ITN', async () => {
     const { default: createSpeechRecognitionPonyfill } = require('./createSpeechRecognitionPonyfill');
-    const { SpeechRecognition } = await createSpeechRecognitionPonyfill({
+    const { SpeechRecognition } = createSpeechRecognitionPonyfill({
       region: 'westus',
       subscriptionKey: 'SUBSCRIPTION_KEY',
       textNormalization: 'maskeditn'
@@ -1167,5 +1167,23 @@ describe('SpeechRecognition with text normalization', () => {
 
     expect(toSnapshot(events)).toMatchSnapshot();
     expect(events[events.length - 2].results[0][0]).toHaveProperty('transcript', 'no (MaskedITN)');
+  });
+});
+
+describe('SpeechRecognition with Custom Speech', () => {
+  let speechRecognition;
+
+  test('should set up SpeechConfig with endpoint ID', async () => {
+    const { default: createSpeechRecognitionPonyfill } = require('./createSpeechRecognitionPonyfill');
+    const { SpeechRecognition } = createSpeechRecognitionPonyfill({
+      region: 'westus',
+      speechRecognitionEndpointId: '12345678-1234-5678-abcd-12345678abcd',
+      subscriptionKey: 'SUBSCRIPTION_KEY'
+    });
+
+    speechRecognition = new SpeechRecognition();
+    speechRecognition.start();
+
+    expect(recognizer.speechConfig).toHaveProperty('endpointId', '12345678-1234-5678-abcd-12345678abcd');
   });
 });

--- a/packages/component/src/SpeechServices/TextToSpeech/SpeechSynthesisUtterance.js
+++ b/packages/component/src/SpeechServices/TextToSpeech/SpeechSynthesisUtterance.js
@@ -80,6 +80,7 @@ export default class extends DOMEventEmitter {
   async preload() {
     this.arrayBufferPromise = fetchSpeechData({
       authorizationToken: this.authorizationToken,
+      deploymentId: this.deploymentId,
       lang: this.lang || window.navigator.language,
       outputFormat: this.outputFormat,
       pitch: this.pitch,

--- a/packages/component/src/SpeechServices/TextToSpeech/createSpeechSynthesisPonyfill.js
+++ b/packages/component/src/SpeechServices/TextToSpeech/createSpeechSynthesisPonyfill.js
@@ -19,6 +19,7 @@ export default ({
     AudioContext: window.AudioContext || window.webkitAudioContext
   },
   region = 'westus',
+  speechSynthesisDeploymentId,
   subscriptionKey
 }) => {
   if (!authorizationToken && !subscriptionKey) {
@@ -89,6 +90,7 @@ export default ({
         utterance.addEventListener('error', reject);
 
         utterance.authorizationToken = await getAuthorizationTokenPromise;
+        utterance.deploymentId = speechSynthesisDeploymentId;
         utterance.region = region;
         utterance.outputFormat = this.outputFormat;
         utterance.preload();
@@ -102,9 +104,17 @@ export default ({
     }
 
     async updateVoices() {
-      this.voices = await fetchVoices({ authorizationToken: await getAuthorizationTokenPromise, region });
+      if (!speechSynthesisDeploymentId) {
+        // Fetch voice list is not available for custom voice font
 
-      this.emit('voiceschanged');
+        this.voices = await fetchVoices({
+          authorizationToken: await getAuthorizationTokenPromise,
+          deploymentId: speechSynthesisDeploymentId,
+          region
+        });
+
+        this.emit('voiceschanged');
+      }
     }
   }
 

--- a/packages/component/src/SpeechServices/TextToSpeech/fetchSpeechData.js
+++ b/packages/component/src/SpeechServices/TextToSpeech/fetchSpeechData.js
@@ -4,10 +4,12 @@ import buildSSML from './buildSSML';
 const DEFAULT_LANGUAGE = 'en-US';
 const DEFAULT_VOICE = 'Microsoft Server Speech Text to Speech Voice (en-US, JessaRUS)'
 const EMPTY_MP3_BASE64 = 'SUQzBAAAAAAAI1RTU0UAAAAPAAADTGF2ZjU3LjU2LjEwMQAAAAAAAAAAAAAA//tAwAAAAAAAAAAAAAAAAAAAAAAASW5mbwAAAA8AAAACAAABhgC7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7//////////////////////////////////////////////////////////////////8AAAAATGF2YzU3LjY0AAAAAAAAAAAAAAAAJAUHAAAAAAAAAYYoRBqpAAAAAAD/+xDEAAPAAAGkAAAAIAAANIAAAARMQU1FMy45OS41VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVf/7EMQpg8AAAaQAAAAgAAA0gAAABFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV';
+const SYNTHESIS_CUSTOM_VOICE_URL_TEMPLATE = 'https://{region}.voice.speech.microsoft.com/cognitiveservices/v1?deploymentId={deploymentId}';
 const SYNTHESIS_URL_TEMPLATE = 'https://{region}.tts.speech.microsoft.com/cognitiveservices/v1';
 
 export default async function ({
   authorizationToken,
+  deploymentId,
   lang = DEFAULT_LANGUAGE,
   outputFormat,
   pitch,
@@ -25,7 +27,10 @@ export default async function ({
   const ssml = buildSSML({ lang, pitch, rate, text, voice, volume });
 
   // Although calling encodeURI on hostname does not actually works, it fails faster and safer.
-  const url = SYNTHESIS_URL_TEMPLATE.replace(/\{region\}/, encodeURI(region));
+  const url = deploymentId ?
+    SYNTHESIS_CUSTOM_VOICE_URL_TEMPLATE.replace(/\{region\}/, encodeURI(region)).replace(/\{deploymentId\}/, encodeURI(deploymentId))
+  :
+    SYNTHESIS_URL_TEMPLATE.replace(/\{region\}/, encodeURI(region));
 
   const res = await fetch(url, {
     headers: {

--- a/packages/component/src/SpeechServices/TextToSpeech/fetchVoices.js
+++ b/packages/component/src/SpeechServices/TextToSpeech/fetchVoices.js
@@ -1,10 +1,13 @@
 import SpeechSynthesisVoice from './SpeechSynthesisVoice';
 
-export default async function ({ authorizationToken, region }) {
+export default async function ({ authorizationToken, deploymentId, region }) {
   // Although encodeURI on a hostname doesn't work as expected, at least, it will fail peacefully.
 
   const res = await fetch(
-    `https://${ encodeURI(region) }.tts.speech.microsoft.com/cognitiveservices/voices/list`,
+    deploymentId ?
+      `https://${ encodeURI(region) }.voice.speech.microsoft.com/cognitiveservices/voices/list?deploymentId=${ encodeURIComponent(deploymentId) }`
+    :
+      `https://${ encodeURI(region) }.tts.speech.microsoft.com/cognitiveservices/voices/list`,
     {
       headers: {
         authorization: `Bearer ${ authorizationToken }`,

--- a/packages/playground/src/SpeechSynthesisProvingGround.js
+++ b/packages/playground/src/SpeechSynthesisProvingGround.js
@@ -1,11 +1,16 @@
+import { connect } from 'react-redux';
 import React from 'react';
 
 import SpeechSynthesisCommands from './UI/SpeechSynthesisCommands';
+import SpeechSynthesisDeploymentIdInput from './UI/SpeechSynthesisDeploymentIdInput';
 import SpeechSynthesisTextBox from './UI/SpeechSynthesisTextBox';
 import SpeechSynthesisUtterances from './UI/SpeechSynthesisUtterances';
 import SpeechSynthesisVoiceSelector from './UI/SpeechSynthesisVoiceSelector';
+import SpeechSynthesisVoiceURIInput from './UI/SpeechSynthesisVoiceURIInput';
 
-export default () =>
+const SpeechSynthesisProvingGround = ({
+  hasVoices
+}) =>
   <div>
     <form>
       <div className="row">
@@ -17,10 +22,27 @@ export default () =>
       <br />
       <div className="row">
         <div className="col">
-          <label>Voice</label>
-          <SpeechSynthesisVoiceSelector />
+          <label>Deployment ID</label>
+          <SpeechSynthesisDeploymentIdInput />
         </div>
       </div>
+      <br />
+      {
+        hasVoices ?
+          <div className="row">
+            <div className="col">
+              <label>Voice</label>
+              <SpeechSynthesisVoiceSelector />
+            </div>
+          </div>
+        :
+          <div className="row">
+            <div className="col">
+              <label>Voice URI</label>
+              <SpeechSynthesisVoiceURIInput />
+            </div>
+          </div>
+      }
     </form>
     <br />
     <div className="row">
@@ -35,3 +57,11 @@ export default () =>
       </div>
     </div>
   </div>
+
+export default connect(
+  ({
+    speechSynthesisNativeVoices
+  }) => ({
+    hasVoices: !!speechSynthesisNativeVoices.length
+  })
+)(SpeechSynthesisProvingGround)

--- a/packages/playground/src/UI/SpeechRecognitionCommands.js
+++ b/packages/playground/src/UI/SpeechRecognitionCommands.js
@@ -2,6 +2,7 @@ import { connect } from 'react-redux';
 import React, { useMemo, useState } from 'react';
 
 import Select, { Option } from '../Bootstrap/Select';
+import SpeechRecognitionEndpointIdInput from './SpeechRecognitionEndpointIdInput';
 import SpeechRecognitionLanguageSelector from './SpeechRecognitionLanguageSelector';
 import SpeechRecognitionTextNormalizationSelector from './SpeechRecognitionTextNormalizationSelector';
 
@@ -167,6 +168,10 @@ const SpeechRecognitionCommands = ({
             type="text"
             value={ referenceGrammarsString }
           />
+        </div>
+        <div className="col">
+          <label>Endpoint ID</label>
+          <SpeechRecognitionEndpointIdInput />
         </div>
       </div>
     </React.Fragment>

--- a/packages/playground/src/UI/SpeechRecognitionEndpointIdInput.js
+++ b/packages/playground/src/UI/SpeechRecognitionEndpointIdInput.js
@@ -1,0 +1,30 @@
+import { connect } from 'react-redux';
+import React from 'react';
+
+import setSpeechRecognitionEndpointId from '../data/actions/setSpeechRecognitionEndpointId';
+
+const SpeechRecognitionEndpointIdInput = ({
+  disabled,
+  endpointId,
+  setSpeechRecognitionEndpointId
+}) =>
+  <input
+    className="form-control"
+    disabled={ disabled }
+    onChange={ setSpeechRecognitionEndpointId }
+    type="text"
+    value={ endpointId }
+  />
+
+export default connect(
+  ({
+    ponyfillType,
+    speechRecognitionEndpointId
+  }) => ({
+    disabled: ponyfillType === 'browser' || ponyfillType === 'bingspeech',
+    endpointId: speechRecognitionEndpointId
+  }),
+  {
+    setSpeechRecognitionEndpointId: ({ target: { value } }) => setSpeechRecognitionEndpointId(value)
+  }
+)(SpeechRecognitionEndpointIdInput)

--- a/packages/playground/src/UI/SpeechRecognitionSimpleEvents.js
+++ b/packages/playground/src/UI/SpeechRecognitionSimpleEvents.js
@@ -65,7 +65,7 @@ const SpeechRecognitionSimpleEvents = ({
               : event.type === 'error' ?
                 <React.Fragment>
                   <span className="badge badge-dark">{ event.type }</span>&nbsp;
-                  { event.error }
+                  <small>{ event.message }</small>
                 </React.Fragment>
               : event.type === 'cognitiveservices' ?
                 <span className="badge badge-light">{ event.type }:{ event.subType }</span>

--- a/packages/playground/src/UI/SpeechSynthesisDeploymentIdInput.js
+++ b/packages/playground/src/UI/SpeechSynthesisDeploymentIdInput.js
@@ -1,0 +1,30 @@
+import { connect } from 'react-redux';
+import React from 'react';
+
+import setSpeechSynthesisDeploymentId from '../data/actions/setSpeechSynthesisDeploymentId';
+
+const SpeechSynthesisDeploymentId = ({
+  disabled,
+  deploymentId,
+  setSpeechSynthesisDeploymentId
+}) =>
+  <input
+    className="form-control"
+    disabled={ disabled }
+    onChange={ setSpeechSynthesisDeploymentId }
+    type="text"
+    value={ deploymentId }
+  />
+
+export default connect(
+  ({
+    ponyfillType,
+    speechSynthesisDeploymentId
+  }) => ({
+    disabled: ponyfillType === 'browser' || ponyfillType === 'bingspeech',
+    deploymentId: speechSynthesisDeploymentId
+  }),
+  {
+    setSpeechSynthesisDeploymentId: ({ target: { value } }) => setSpeechSynthesisDeploymentId(value)
+  }
+)(SpeechSynthesisDeploymentId)

--- a/packages/playground/src/UI/SpeechSynthesisDeploymentIdInput.js
+++ b/packages/playground/src/UI/SpeechSynthesisDeploymentIdInput.js
@@ -3,7 +3,7 @@ import React from 'react';
 
 import setSpeechSynthesisDeploymentId from '../data/actions/setSpeechSynthesisDeploymentId';
 
-const SpeechSynthesisDeploymentId = ({
+const SpeechSynthesisDeploymentIdInput = ({
   disabled,
   deploymentId,
   setSpeechSynthesisDeploymentId
@@ -27,4 +27,4 @@ export default connect(
   {
     setSpeechSynthesisDeploymentId: ({ target: { value } }) => setSpeechSynthesisDeploymentId(value)
   }
-)(SpeechSynthesisDeploymentId)
+)(SpeechSynthesisDeploymentIdInput)

--- a/packages/playground/src/UI/SpeechSynthesisVoiceSelector.js
+++ b/packages/playground/src/UI/SpeechSynthesisVoiceSelector.js
@@ -10,16 +10,19 @@ const SpeechSynthesisVoiceSelector = ({
   speechSynthesisVoiceURI
 }) =>
   <Select
+    disabled={ !speechSynthesisNativeVoices.length }
     onChange={ setSpeechSynthesisVoiceURI }
     value={ speechSynthesisVoiceURI || '' }
   >
-    { speechSynthesisNativeVoices.map(({ name, voiceURI }) =>
-      <Option
-        key={ voiceURI }
-        text={ name }
-        value={ voiceURI }
-      />
-    ) }
+    {
+      speechSynthesisNativeVoices.map(({ name, voiceURI }) =>
+        <Option
+          key={ voiceURI }
+          text={ name }
+          value={ voiceURI }
+        />
+      )
+    }
   </Select>
 
 export default connect(

--- a/packages/playground/src/UI/SpeechSynthesisVoiceURIInput.js
+++ b/packages/playground/src/UI/SpeechSynthesisVoiceURIInput.js
@@ -1,0 +1,31 @@
+import { connect } from 'react-redux';
+import React from 'react';
+
+import setSpeechSynthesisVoiceURI from '../data/actions/setSpeechSynthesisVoiceURI';
+
+const SpeechSynthesisVoiceURIInput = ({
+  disabled,
+  speechSynthesisVoiceURI,
+  setSpeechSynthesisVoiceURI
+}) =>
+  <input
+    className="form-control"
+    disabled={ disabled }
+    onChange={ setSpeechSynthesisVoiceURI }
+    type="text"
+    value={ speechSynthesisVoiceURI }
+  />
+
+export default connect(
+  ({
+    ponyfillType,
+    speechSynthesisDeploymentId,
+    speechSynthesisVoiceURI
+  }) => ({
+    disabled: ponyfillType === 'browser' || ponyfillType === 'bingspeech' || !speechSynthesisDeploymentId,
+    speechSynthesisVoiceURI
+  }),
+  {
+    setSpeechSynthesisVoiceURI: ({ target: { value } }) => setSpeechSynthesisVoiceURI(value)
+  }
+)(SpeechSynthesisVoiceURIInput)

--- a/packages/playground/src/data/actions/setSpeechRecognitionEndpointId.js
+++ b/packages/playground/src/data/actions/setSpeechRecognitionEndpointId.js
@@ -1,0 +1,10 @@
+const SET_SPEECH_RECOGNITION_ENDPOINT_ID = 'SET_SPEECH_RECOGNITION_ENDPOINT_ID';
+
+export default function (endpointId) {
+  return {
+    type: SET_SPEECH_RECOGNITION_ENDPOINT_ID,
+    payload: { endpointId }
+  };
+}
+
+export { SET_SPEECH_RECOGNITION_ENDPOINT_ID }

--- a/packages/playground/src/data/actions/setSpeechSynthesisDeploymentId.js
+++ b/packages/playground/src/data/actions/setSpeechSynthesisDeploymentId.js
@@ -1,0 +1,10 @@
+const SET_SPEECH_SYNTHESIS_DEPLOYMENT_ID = 'SET_SPEECH_SYNTHESIS_DEPLOYMENT_ID';
+
+export default function (deploymentId) {
+  return {
+    type: SET_SPEECH_SYNTHESIS_DEPLOYMENT_ID,
+    payload: { deploymentId }
+  };
+}
+
+export { SET_SPEECH_SYNTHESIS_DEPLOYMENT_ID }

--- a/packages/playground/src/data/reducer.js
+++ b/packages/playground/src/data/reducer.js
@@ -9,6 +9,7 @@ import ponyfill from './reducers/ponyfill';
 import ponyfillType from './reducers/ponyfillType';
 import region from './reducers/region';
 import speechRecognitionContinuous from './reducers/speechRecognitionContinuous';
+import speechRecognitionEndpointId from './reducers/speechRecognitionEndpointId';
 import speechRecognitionEvents from './reducers/speechRecognitionEvents';
 import speechRecognitionInterimResults from './reducers/speechRecognitionInterimResults';
 import speechRecognitionLanguage from './reducers/speechRecognitionLanguage';
@@ -19,6 +20,7 @@ import speechRecognitionStarted from './reducers/speechRecognitionStarted';
 import speechRecognitionTextNormalization from './reducers/speechRecognitionTextNormalization';
 import speechServicesAuthorizationToken from './reducers/speechServicesAuthorizationToken';
 import speechServicesSubscriptionKey from './reducers/speechServicesSubscriptionKey';
+import speechSynthesisDeploymentId from './reducers/speechSynthesisDeploymentId';
 import speechSynthesisNativeVoices from './reducers/speechSynthesisNativeVoices';
 import speechSynthesisText from './reducers/speechSynthesisText';
 import speechSynthesisUtterances from './reducers/speechSynthesisUtterances';
@@ -34,6 +36,7 @@ export default combineReducers({
   ponyfillType,
   region,
   speechRecognitionContinuous,
+  speechRecognitionEndpointId,
   speechRecognitionEvents,
   speechRecognitionInterimResults,
   speechRecognitionLanguage,
@@ -44,6 +47,7 @@ export default combineReducers({
   speechRecognitionTextNormalization,
   speechServicesAuthorizationToken,
   speechServicesSubscriptionKey,
+  speechSynthesisDeploymentId,
   speechSynthesisNativeVoices,
   speechSynthesisText,
   speechSynthesisUtterances,

--- a/packages/playground/src/data/reducers/speechRecognitionEndpointId.js
+++ b/packages/playground/src/data/reducers/speechRecognitionEndpointId.js
@@ -1,0 +1,9 @@
+import { SET_SPEECH_RECOGNITION_ENDPOINT_ID } from '../actions/setSpeechRecognitionEndpointId';
+
+export default function (state = '', { payload, type }) {
+  if (type === SET_SPEECH_RECOGNITION_ENDPOINT_ID) {
+    state = payload.endpointId;
+  }
+
+  return state;
+}

--- a/packages/playground/src/data/reducers/speechSynthesisDeploymentId.js
+++ b/packages/playground/src/data/reducers/speechSynthesisDeploymentId.js
@@ -1,0 +1,9 @@
+import { SET_SPEECH_SYNTHESIS_DEPLOYMENT_ID } from '../actions/setSpeechSynthesisDeploymentId';
+
+export default function (state = '', { payload, type }) {
+  if (type === SET_SPEECH_SYNTHESIS_DEPLOYMENT_ID) {
+    state = payload.deploymentId;
+  }
+
+  return state;
+}

--- a/packages/playground/src/data/sagas/setPonyfill.js
+++ b/packages/playground/src/data/sagas/setPonyfill.js
@@ -10,10 +10,12 @@ import { SET_BING_SPEECH_SUBSCRIPTION_KEY } from '../actions/setBingSpeechSubscr
 import { SET_ON_DEMAND_AUTHORIZATION_TOKEN } from '../actions/setOnDemandAuthorizationToken';
 import { SET_PONYFILL_TYPE } from '../actions/setPonyfillType';
 import { SET_REGION } from '../actions/setRegion';
+import { SET_SPEECH_RECOGNITION_ENDPOINT_ID } from '../actions/setSpeechRecognitionEndpointId';
 import { SET_SPEECH_RECOGNITION_REFERENCE_GRAMMARS } from '../actions/setSpeechRecognitionReferenceGrammars';
 import { SET_SPEECH_RECOGNITION_TEXT_NORMALIZATION } from '../actions/setSpeechRecognitionTextNormalization';
 import { SET_SPEECH_SERVICES_AUTHORIZATION_TOKEN } from '../actions/setSpeechServicesAuthorizationToken';
 import { SET_SPEECH_SERVICES_SUBSCRIPTION_KEY } from '../actions/setSpeechServicesSubscriptionKey';
+import { SET_SPEECH_SYNTHESIS_DEPLOYMENT_ID } from '../actions/setSpeechSynthesisDeploymentId';
 import setPonyfill from '../actions/setPonyfill';
 
 import createBingSpeechPonyfill, { fetchAuthorizationToken as fetchBingSpeechAuthorizationToken } from 'web-speech-cognitive-services/lib/BingSpeech';
@@ -29,9 +31,11 @@ export default function* () {
       || type === SET_PONYFILL_TYPE
       || type === SET_REGION
       || type === SET_SPEECH_RECOGNITION_REFERENCE_GRAMMARS
+      || type === SET_SPEECH_RECOGNITION_ENDPOINT_ID
       || type === SET_SPEECH_RECOGNITION_TEXT_NORMALIZATION
       || type === SET_SPEECH_SERVICES_AUTHORIZATION_TOKEN
       || type === SET_SPEECH_SERVICES_SUBSCRIPTION_KEY
+      || type === SET_SPEECH_SYNTHESIS_DEPLOYMENT_ID
       || type === SET_ON_DEMAND_AUTHORIZATION_TOKEN,
     setPonyfillSaga
   );
@@ -44,10 +48,12 @@ function* setPonyfillSaga() {
     onDemandAuthorizationToken,
     ponyfillType,
     region,
+    speechRecognitionEndpointId,
     speechRecognitionReferenceGrammars: referenceGrammars,
     speechRecognitionTextNormalization: textNormalization,
     speechServicesAuthorizationToken,
-    speechServicesSubscriptionKey
+    speechServicesSubscriptionKey,
+    speechSynthesisDeploymentId
   } = yield select();
 
   if (ponyfillType === 'browser') {
@@ -69,7 +75,11 @@ function* setPonyfillSaga() {
           authorizationToken: onDemandAuthorizationToken ? () => {
             console.log('On-demand fetching Bing Speech authorization token');
 
-            return fetchBingSpeechAuthorizationToken(bingSpeechSubscriptionKey);
+            try {
+              return fetchBingSpeechAuthorizationToken(bingSpeechSubscriptionKey);
+            } catch (err) {
+              console.error('Failed to fetch Bing Speech authorization token', err);
+            }
           } : null,
           subscriptionKey: onDemandAuthorizationToken ? null : bingSpeechSubscriptionKey
         }
@@ -80,6 +90,8 @@ function* setPonyfillSaga() {
     const options = {
       referenceGrammars,
       region,
+      speechRecognitionEndpointId,
+      speechSynthesisDeploymentId,
       textNormalization
     };
 
@@ -93,10 +105,14 @@ function* setPonyfillSaga() {
           authorizationToken: onDemandAuthorizationToken ? () => {
             console.log('On-demand fetching Speech Services authorization token');
 
-            return fetchSpeechServicesAuthorizationToken({
-              region,
-              subscriptionKey: speechServicesSubscriptionKey
-            });
+            try {
+              return fetchSpeechServicesAuthorizationToken({
+                region,
+                subscriptionKey: speechServicesSubscriptionKey
+              });
+            } catch (err) {
+              console.error('Failed to fetch Speech Services authorization token', err);
+            }
           } : null,
           subscriptionKey: onDemandAuthorizationToken ? null : speechServicesSubscriptionKey
         }

--- a/packages/playground/src/data/sagas/speechSynthesisSpeakUtterance.js
+++ b/packages/playground/src/data/sagas/speechSynthesisSpeakUtterance.js
@@ -30,6 +30,8 @@ export default function* () {
 
     if (nativeVoice) {
       nativeUtterance.voice = nativeVoice;
+    } else {
+      nativeUtterance.voice = { voiceURI };
     }
 
     yield put(addSpeechSynthesisNativeUtterance(nativeUtterance));


### PR DESCRIPTION
> Fix #27 and fix #28.

## Description

Adding support for custom speech and custom voice font.

Custom speech requires "endpoint ID", passed as option named `speechRecognitionEndpointId`.

Custom voice font requires "deployment ID" and "voice URI", passed as option named `speechSynthesisDeploymentId`. Voice list cannot be fetch and must be manually selected by setting `SpeechSynthesisUtterance.voice = { voiceURI: 'your-voice-uri' }`.

## Changelog

### Added

- Speech recognition: Fix [#27](https://github.com/compulim/web-speech-cognitive-services/issues/27), support custom speech, in PR [#41](https://github.com/compulim/web-speech-cognitive-services/pull/41)
   - Use option `speechRecognitionEndpointId`
- Speech synthesis: Fix [#28](https://github.com/compulim/web-speech-cognitive-services/issues/28), support custom voice font, in PR [#41](https://github.com/compulim/web-speech-cognitive-services/pull/41)
   - Use option `speechSynthesisDeploymentId`
