### PR TITLE
Emit error if failed to synthesize on fetching audio clip

### DIFF
--- a/SPEC-SYNTHESIS.md
+++ b/SPEC-SYNTHESIS.md
@@ -80,3 +80,16 @@ We tested the following behaviors:
 - Call `speechSynthesis.resume()`
 - Expect: no additional events from both of the utterances
 - Expect: `speaking` property is continue to be `false`
+
+## Network error
+
+> Testing against server-based voice.
+
+- Speak an utterance
+- Expect: receive `start` event
+- (A few seconds later)
+- Expect: receive `error` event of type `SpeechSynthesisErrorEvent`
+   - `error` field set to `"synthesis-failed"`
+   - `utterance` field set to the `SpeechSynthesisUtterance instance
+   - `elapsedTime` field is set
+- There will be no `end `event

--- a/packages/component/src/SpeechServices/TextToSpeech/createSpeechSynthesisPonyfill.js
+++ b/packages/component/src/SpeechServices/TextToSpeech/createSpeechSynthesisPonyfill.js
@@ -89,7 +89,7 @@ export default ({
         utterance.addEventListener('end', resolve);
         utterance.addEventListener('error', reject);
 
-        utterance.authorizationToken = await getAuthorizationTokenPromise;
+        utterance.authorizationTokenPromise = getAuthorizationTokenPromise;
         utterance.deploymentId = speechSynthesisDeploymentId;
         utterance.region = region;
         utterance.outputFormat = this.outputFormat;
@@ -105,15 +105,19 @@ export default ({
 
     async updateVoices() {
       if (!speechSynthesisDeploymentId) {
-        // Fetch voice list is not available for custom voice font
+        // Fetch voice list is not available for custom voice font.
+        // If fetch voice list failed, we will not emit "voiceschanged" event.
+        // In the spec, there is no "error" event.
 
-        this.voices = await fetchVoices({
-          authorizationToken: await getAuthorizationTokenPromise,
-          deploymentId: speechSynthesisDeploymentId,
-          region
-        });
+        try {
+          this.voices = await fetchVoices({
+            authorizationToken: await getAuthorizationTokenPromise,
+            deploymentId: speechSynthesisDeploymentId,
+            region
+          });
 
-        this.emit('voiceschanged');
+          this.emit('voiceschanged');
+        } catch (err) {}
       }
     }
   }

--- a/packages/component/src/SpeechServices/TextToSpeech/fetchSpeechData.js
+++ b/packages/component/src/SpeechServices/TextToSpeech/fetchSpeechData.js
@@ -8,7 +8,7 @@ const SYNTHESIS_CUSTOM_VOICE_URL_TEMPLATE = 'https://{region}.voice.speech.micro
 const SYNTHESIS_URL_TEMPLATE = 'https://{region}.tts.speech.microsoft.com/cognitiveservices/v1';
 
 export default async function ({
-  authorizationToken,
+  authorizationTokenPromise,
   deploymentId,
   lang = DEFAULT_LANGUAGE,
   outputFormat,
@@ -24,6 +24,7 @@ export default async function ({
     return decode(EMPTY_MP3_BASE64);
   }
 
+  const authorizationToken = await authorizationTokenPromise;
   const ssml = buildSSML({ lang, pitch, rate, text, voice, volume });
 
   // Although calling encodeURI on hostname does not actually works, it fails faster and safer.

--- a/packages/playground/src/data/reducers/speechSynthesisVoiceURI.js
+++ b/packages/playground/src/data/reducers/speechSynthesisVoiceURI.js
@@ -1,6 +1,6 @@
 import { SET_SPEECH_SYNTHESIS_VOICE_URI } from '../actions/setSpeechSynthesisVoiceURI';
 
-export default function (state = null, { payload, type }) {
+export default function (state = '', { payload, type }) {
   if (type === SET_SPEECH_SYNTHESIS_VOICE_URI) {
     return payload.voiceURI;
   }

--- a/packages/playground/src/data/sagas/setPonyfill.js
+++ b/packages/playground/src/data/sagas/setPonyfill.js
@@ -95,8 +95,7 @@ function* setPonyfillSaga() {
       textNormalization
     };
 
-    const ponyfill = yield call(
-      createSpeechServicesPonyfill,
+    const ponyfill = createSpeechServicesPonyfill(
       speechServicesAuthorizationToken ?
         { ...options, authorizationToken: speechServicesAuthorizationToken }
       :


### PR DESCRIPTION
> Fix #45.

### Fixed

- Fix [#45](https://github.com/compulim/web-speech-cognitive-services/issues/45). Speech synthesize should emit "start" and "error" if the synthesized audio clip cannot be fetch over the network, in PR [#46](https://github.com/compulim/web-speech-cognitive-services/issues/46)
