### PR TITLE
Add speech synthesis output format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
    - Use option `speechRecognitionEndpointId`
 - Speech synthesis: Fix [#28](https://github.com/compulim/web-speech-cognitive-services/issues/28), support custom voice font, in PR [#41](https://github.com/compulim/web-speech-cognitive-services/pull/41)
    - Use option `speechSynthesisDeploymentId`
+- Speech synthesis: Fix [#48](https://github.com/compulim/web-speech-cognitive-services/issues/48), support output format through `outputFormat` option, in PR [#49](https://github.com/compulim/web-speech-cognitive-services/pull/49)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ In the sample below, we use the bundle to perform text-to-speech with a voice na
   <body>
     <script>
       const { speechSynthesis, SpeechSynthesisUtterance } = window.WebSpeechCognitiveServices.create({
-        region: 'westus2',
+        region: 'westus',
         subscriptionKey: 'YOUR_SUBSCRIPTION_KEY'
       });
 
@@ -80,6 +80,111 @@ For development build, run `npm install web-speech-cognitive-services@master`.
 In JavaScript, polyfill is a technique to bring newer features to older environment. Ponyfill is very similar, but instead polluting the environment by default, we prefer to let the developer to choose what they want. This [article](https://ponyfoo.com/articles/polyfills-or-ponyfills) talks about polyfill vs. ponyfill.
 
 In this package, we prefer ponyfill because it do not pollute the hosting environment. You are also free to mix-and-match multiple speech recognition engines under a single environment.
+
+## Options
+
+The following list all options supported by the adapter.
+
+<table>
+  <thead>
+    <tr>
+      <th>Name and type</th>
+      <th>Default value</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>audioConfig:&nbsp;<a href="https://docs.microsoft.com/en-us/javascript/api/microsoft-cognitiveservices-speech-sdk/audioconfig?view=azure-node-latest">AudioConfig</a></code></td>
+      <td><code><a href="https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/how-to-select-audio-input-devices#audio-device-ids-in-javascript">fromDefaultMicrophoneInput()</a></code></td>
+      <td>
+        <a href="https://docs.microsoft.com/en-us/javascript/api/microsoft-cognitiveservices-speech-sdk/audioconfig?view=azure-node-latest"><code>AudioConfig</code></a> object to use with speech recognition. Please refer to <a href="https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/how-to-select-audio-input-devices#audio-device-ids-in-javascript">this article</a> for details on selecting different audio devices.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>audioContext:&nbsp;<a href="https://developer.mozilla.org/en-US/docs/Web/API/AudioContext">AudioContext</a></code>
+      </td>
+      <td><code>undefined</code></td>
+      <td>
+        The audio context is synthesizing speech on. If this is <code>undefined</code>, the <code>AudioContext</code> object will be created on first synthesis.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>authorizationToken:&nbsp;(</code><br />
+        <code>&nbsp;&nbsp;string&nbsp;||</code><br />
+        <code>&nbsp;&nbsp;Promise&lt;string&gt;&nbsp;||</code><br />
+        <code>&nbsp;&nbsp;()&nbsp;=>&nbsp;string&nbsp;||</code><br />
+        <code>&nbsp;&nbsp;()&nbsp;=>&nbsp;Promise&lt;string&gt;</code><br />
+        <code>)</code>
+      </td>
+      <td>(Requires either<br /><code>authorizationToken</code> or<br /><code>subscriptionKey</code>)</td>
+      <td>
+        Authorization token from Cognitive Services. Please refer to <a href="https://docs.microsoft.com/en-us/azure/cognitive-services/authentication">this article</a> to obtain an authorization token.
+      </td>
+    </tr>
+    <tr>
+      <td><code>ponyfill.AudioContext:&nbsp;<a href="https://developer.mozilla.org/en-US/docs/Web/API/AudioContext">AudioContext</a></code></td>
+      <td><code>window.AudioContext&nbsp;||</code><br /><code>window.webkitAudioContext</code></td>
+      <td>
+        Ponyfill for Web Audio API.<br /><br />
+        Currently, only Web Audio API can be ponyfilled. We may expand to WebRTC for audio recording in the future.</td>
+      </td>
+    </tr>
+    <tr>
+      <td><code>referenceGrammars:&nbsp;string[]</code></td>
+      <td><code>undefined</code></td>
+      <td>Reference grammar IDs to send for speech recognition.</td>
+    </tr>
+    <tr>
+      <td><code>region:&nbsp;string</code></td>
+      <td><code>"westus"</code></td>
+      <td>
+        Azure region of Cognitive Services to use.
+      </td>
+    </tr>
+    <tr>
+      <td><code>speechRecognitionEndpointId:&nbsp;string</code></td>
+      <td><code>undefined</code></td>
+      <td>
+        Endpoint ID for <a href="https://azure.microsoft.com/en-us/services/cognitive-services/custom-speech-service/">Custom Speech service</a>.
+      </td>
+    <tr>
+      <td><code>speechSynthesisDeploymentId:&nbsp;string</code></td>
+      <td><code>undefined</code></td>
+      <td>
+        Deployment ID for <a href="https://speech.microsoft.com/customvoice">Custom Voice service</a>.<br /><br />
+        When you are using Custom Voice, you will need to specify your voice model name through <a href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesisVoice"><code>SpeechSynthesisVoice.voiceURI</code></a>. Please refer to the <a href="#custom-voice-support">"Custom Voice support"</a> section for details.
+      </td>
+    </tr>
+    <tr>
+      <td><code>speechSynthesisOutputFormat:&nbsp;string</code></td>
+      <td><code>audio-24khz-160kbitrate-mono-mp3</code></td>
+      <td>Audio format for speech synthesis. Please refer to <a href="https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/rest-text-to-speech#audio-outputs">this article</a> for list of supported formats.</td>
+    </tr>
+    <tr>
+      <td><code>subscriptionKey:&nbsp;string</code></td>
+      <td>(Requires either<br /><code>authorizationToken</code> or<br /><code>subscriptionKey</code>)</td>
+      <td>
+        Subscription key to use. This is not recommended for production use as the subscription key will be leaked in the browser.
+      </td>
+    </tr>
+    <tr>
+      <td><code>textNormalization:&nbsp;string</code></td>
+      <td><code>"display"</code></td>
+      <td>
+        Supported text normalization options:<br /><br />
+        <ul>
+          <li><code>"display"</code></li>
+          <li><code>"itn"</code> (inverse text normalization)</li>
+          <li><code>"lexical"</code></li>
+          <li><code>"maskeditn"</code> (masked ITN)</li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 # Code snippets
 
@@ -159,7 +264,7 @@ const {
 const recognition = new SpeechRecognition();
 
 recognition.grammars = new SpeechGrammarList();
-recognition.grammars.words = ['Tuen Mun', 'Yuen Long'];
+recognition.grammars.phrases = ['Tuen Mun', 'Yuen Long'];
 
 recognition.onresult = ({ results }) => {
   console.log(results);
@@ -254,13 +359,13 @@ const ponyfill = await createPonyfill({
 });
 ```
 
-You can also provide an async function that will fetch the authorization token on-demand. You should cache the authorization token for subsequent request.
+You can also provide an async function that will fetch the authorization token on-demand. You should cache the authorization token for subsequent request. For simplicity of this code snippets, we are not caching the result.
 
 ```jsx
 import createPonyfill from 'web-speech-cognitive-services/lib/SpeechServices';
 
 const ponyfill = await createPonyfill({
-  authorizationToken: fetch('https://example.com/your-token').then(res => res.text()),
+  authorizationToken: () => fetch('https://example.com/your-token').then(res => res.text()),
   region: 'westus',
 });
 ```
@@ -326,17 +431,12 @@ For detailed test matrix, please refer to [`SPEC-RECOGNITION.md`](SPEC-RECOGNITI
       * We always return `0.5` for interim results
    * Cognitive Services support grammar list but not in JSGF format, more work to be done in this area
       * Although Google Chrome support grammar list, it seems the grammar list is not used at all
-   * Continuous mode does not work
+   * Continuous mode
+      * `stop()` is same as `abort()`
+      * If `stop()` is called before first `recognized` event, there will be no final result
 * Speech synthesis
    * `onboundary`, `onmark`, `onpause`, and `onresume` are not supported/fired
    * `pause` will pause immediately and do not pause on word breaks
-
-## Quirks
-
-* Speech recognition
-   * Dictation mode
-      * If `stop()` is called before first `recognized` event, there will be no final result
-      * Cognitive Services stop recognition immediately after `stop()` is called
 
 # Roadmap
 

--- a/packages/component/src/SpeechServices/TextToSpeech/SpeechSynthesisUtterance.js
+++ b/packages/component/src/SpeechServices/TextToSpeech/SpeechSynthesisUtterance.js
@@ -77,15 +77,20 @@ export default class extends DOMEventEmitter {
   get volume() { return this._volume; }
   set volume(value) { this._volume = value; }
 
-  async preload() {
+  async preload({
+    authorizationTokenPromise,
+    deploymentId,
+    outputFormat,
+    region
+  }) {
     this.arrayBufferPromise = fetchSpeechData({
-      authorizationTokenPromise: this.authorizationTokenPromise,
-      deploymentId: this.deploymentId,
+      authorizationTokenPromise,
+      deploymentId,
       lang: this.lang || window.navigator.language,
-      outputFormat: this.outputFormat,
+      outputFormat,
       pitch: this.pitch,
       rate: this.rate,
-      region: this.region,
+      region,
       text: this.text,
       voice: this.voice && this.voice.voiceURI,
       volume: this.volume

--- a/packages/component/src/SpeechServices/TextToSpeech/createSpeechSynthesisPonyfill.js
+++ b/packages/component/src/SpeechServices/TextToSpeech/createSpeechSynthesisPonyfill.js
@@ -6,8 +6,8 @@ import fetchAuthorizationToken from '../fetchAuthorizationToken';
 import fetchVoices from './fetchVoices';
 import SpeechSynthesisUtterance from './SpeechSynthesisUtterance';
 
-// Supported output format can be found at https://docs.microsoft.com/en-us/azure/cognitive-services/Speech/API-Reference-REST/BingVoiceOutput#Subscription
-const DEFAULT_OUTPUT_FORMAT = 'audio-16khz-128kbitrate-mono-mp3';
+// Supported output format can be found at https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/rest-text-to-speech#audio-outputs
+const DEFAULT_OUTPUT_FORMAT = 'audio-24khz-160kbitrate-mono-mp3';
 
 const TOKEN_EXPIRATION = 600000;
 const TOKEN_EARLY_RENEWAL = 60000;
@@ -20,6 +20,7 @@ export default ({
   },
   region = 'westus',
   speechSynthesisDeploymentId,
+  speechSynthesisOutputFormat = DEFAULT_OUTPUT_FORMAT,
   subscriptionKey
 }) => {
   if (!authorizationToken && !subscriptionKey) {
@@ -57,7 +58,6 @@ export default ({
     constructor() {
       super(['voiceschanged']);
 
-      this.outputFormat = DEFAULT_OUTPUT_FORMAT;
       this.queue = new AudioContextQueue({ audioContext, ponyfill });
       this.voices = [];
 
@@ -89,11 +89,12 @@ export default ({
         utterance.addEventListener('end', resolve);
         utterance.addEventListener('error', reject);
 
-        utterance.authorizationTokenPromise = getAuthorizationTokenPromise;
-        utterance.deploymentId = speechSynthesisDeploymentId;
-        utterance.region = region;
-        utterance.outputFormat = this.outputFormat;
-        utterance.preload();
+        utterance.preload({
+          authorizationTokenPromise: getAuthorizationTokenPromise,
+          deploymentId: speechSynthesisDeploymentId,
+          outputFormat: speechSynthesisOutputFormat,
+          region: region
+        });
 
         this.queue.push(utterance);
       });

--- a/packages/playground/src/SpeechSynthesisProvingGround.js
+++ b/packages/playground/src/SpeechSynthesisProvingGround.js
@@ -3,6 +3,7 @@ import React from 'react';
 
 import SpeechSynthesisCommands from './UI/SpeechSynthesisCommands';
 import SpeechSynthesisDeploymentIdInput from './UI/SpeechSynthesisDeploymentIdInput';
+import SpeechSynthesisOutputFormatSelector from './UI/SpeechSynthesisOutputFormatSelector';
 import SpeechSynthesisTextBox from './UI/SpeechSynthesisTextBox';
 import SpeechSynthesisUtterances from './UI/SpeechSynthesisUtterances';
 import SpeechSynthesisVoiceSelector from './UI/SpeechSynthesisVoiceSelector';
@@ -27,22 +28,26 @@ const SpeechSynthesisProvingGround = ({
         </div>
       </div>
       <br />
-      {
-        hasVoices ?
-          <div className="row">
-            <div className="col">
-              <label>Voice</label>
-              <SpeechSynthesisVoiceSelector />
-            </div>
-          </div>
-        :
-          <div className="row">
-            <div className="col">
-              <label>Voice URI</label>
-              <SpeechSynthesisVoiceURIInput />
-            </div>
-          </div>
-      }
+      <div className="row">
+        <div className="col col-md-9">
+          {
+            hasVoices ?
+              <React.Fragment>
+                <label>Voice</label>
+                <SpeechSynthesisVoiceSelector />
+              </React.Fragment>
+            :
+              <React.Fragment>
+                <label>Voice URI</label>
+                <SpeechSynthesisVoiceURIInput />
+              </React.Fragment>
+          }
+        </div>
+        <div className="col col-md-3">
+          <label>Output format</label>
+          <SpeechSynthesisOutputFormatSelector />
+        </div>
+      </div>
     </form>
     <br />
     <div className="row">

--- a/packages/playground/src/UI/SpeechSynthesisOutputFormatSelector.js
+++ b/packages/playground/src/UI/SpeechSynthesisOutputFormatSelector.js
@@ -1,0 +1,36 @@
+import { connect } from 'react-redux';
+import React from 'react';
+
+import setSpeechSynthesisOutputFormat from '../data/actions/setSpeechSynthesisOutputFormat';
+import Select, { Option } from '../Bootstrap/Select';
+
+const SpeechSynthesisOutputFormatSelector = ({
+  setSpeechSynthesisOutputFormat,
+  speechSynthesisOutputFormat
+}) =>
+  <Select
+    onChange={ setSpeechSynthesisOutputFormat }
+    value={ speechSynthesisOutputFormat }
+  >
+    <Option text="MP3 160Kbps 24KHz" value="audio-24khz-160kbitrate-mono-mp3" />
+    <Option text="MP3 128Kbps 16KHz" value="audio-16khz-128kbitrate-mono-mp3" />
+    <Option text="MP3 96Kbps 24KHz" value="audio-24khz-96kbitrate-mono-mp3" />
+    <Option text="MP3 64Kbps 16KHz" value="audio-16khz-64kbitrate-mono-mp3" />
+    <Option text="MP3 48Kbps 24KHz" value="audio-24khz-48kbitrate-mono-mp3" />
+    <Option text="MP3 32Kbps 16KHz" value="audio-16khz-32kbitrate-mono-mp3" />
+    <Option text="WAV 24KHz 16-bit PCM" value="riff-24khz-16bit-mono-pcm" />
+    <Option text="WAV 16KHz 16-bit PCM" value="riff-16khz-16bit-mono-pcm" />
+    <Option text="WAV 8KHz 8-bit a-law" value="riff-8khz-8bit-mono-alaw" />
+    <Option text="WAV 8KHz 8-bit &#x03BC;-law" value="riff-8khz-8bit-mono-mulaw" />
+  </Select>
+
+export default connect(
+  ({
+    ponyfill,
+    speechSynthesisOutputFormat
+  }) => ({
+    ponyfill,
+    speechSynthesisOutputFormat
+  }),
+  { setSpeechSynthesisOutputFormat }
+)(SpeechSynthesisOutputFormatSelector)

--- a/packages/playground/src/data/actions/setSpeechSynthesisOutputFormat.js
+++ b/packages/playground/src/data/actions/setSpeechSynthesisOutputFormat.js
@@ -1,0 +1,10 @@
+const SET_SPEECH_SYNTHESIS_OUTPUT_FORMAT = 'SET_SPEECH_SYNTHESIS_OUTPUT_FORMAT';
+
+export default function (outputFormat) {
+  return {
+    type: SET_SPEECH_SYNTHESIS_OUTPUT_FORMAT,
+    payload: { outputFormat }
+  };
+}
+
+export { SET_SPEECH_SYNTHESIS_OUTPUT_FORMAT }

--- a/packages/playground/src/data/reducer.js
+++ b/packages/playground/src/data/reducer.js
@@ -22,6 +22,7 @@ import speechServicesAuthorizationToken from './reducers/speechServicesAuthoriza
 import speechServicesSubscriptionKey from './reducers/speechServicesSubscriptionKey';
 import speechSynthesisDeploymentId from './reducers/speechSynthesisDeploymentId';
 import speechSynthesisNativeVoices from './reducers/speechSynthesisNativeVoices';
+import speechSynthesisOutputFormat from './reducers/speechSynthesisOutputFormat';
 import speechSynthesisText from './reducers/speechSynthesisText';
 import speechSynthesisUtterances from './reducers/speechSynthesisUtterances';
 import speechSynthesisVoiceURI from './reducers/speechSynthesisVoiceURI';
@@ -49,6 +50,7 @@ export default combineReducers({
   speechServicesSubscriptionKey,
   speechSynthesisDeploymentId,
   speechSynthesisNativeVoices,
+  speechSynthesisOutputFormat,
   speechSynthesisText,
   speechSynthesisUtterances,
   speechSynthesisVoiceURI

--- a/packages/playground/src/data/reducers/speechSynthesisOutputFormat.js
+++ b/packages/playground/src/data/reducers/speechSynthesisOutputFormat.js
@@ -1,0 +1,9 @@
+import { SET_SPEECH_SYNTHESIS_OUTPUT_FORMAT } from '../actions/setSpeechSynthesisOutputFormat';
+
+export default function (state = 'audio-24khz-160kbitrate-mono-mp3', { payload, type }) {
+  if( type === SET_SPEECH_SYNTHESIS_OUTPUT_FORMAT) {
+    return payload.outputFormat;
+  }
+
+  return state;
+}

--- a/packages/playground/src/data/sagas/setPonyfill.js
+++ b/packages/playground/src/data/sagas/setPonyfill.js
@@ -16,6 +16,7 @@ import { SET_SPEECH_RECOGNITION_TEXT_NORMALIZATION } from '../actions/setSpeechR
 import { SET_SPEECH_SERVICES_AUTHORIZATION_TOKEN } from '../actions/setSpeechServicesAuthorizationToken';
 import { SET_SPEECH_SERVICES_SUBSCRIPTION_KEY } from '../actions/setSpeechServicesSubscriptionKey';
 import { SET_SPEECH_SYNTHESIS_DEPLOYMENT_ID } from '../actions/setSpeechSynthesisDeploymentId';
+import { SET_SPEECH_SYNTHESIS_OUTPUT_FORMAT } from '../actions/setSpeechSynthesisOutputFormat';
 import setPonyfill from '../actions/setPonyfill';
 
 import createBingSpeechPonyfill, { fetchAuthorizationToken as fetchBingSpeechAuthorizationToken } from 'web-speech-cognitive-services/lib/BingSpeech';
@@ -36,6 +37,7 @@ export default function* () {
       || type === SET_SPEECH_SERVICES_AUTHORIZATION_TOKEN
       || type === SET_SPEECH_SERVICES_SUBSCRIPTION_KEY
       || type === SET_SPEECH_SYNTHESIS_DEPLOYMENT_ID
+      || type === SET_SPEECH_SYNTHESIS_OUTPUT_FORMAT
       || type === SET_ON_DEMAND_AUTHORIZATION_TOKEN,
     setPonyfillSaga
   );
@@ -53,7 +55,8 @@ function* setPonyfillSaga() {
     speechRecognitionTextNormalization: textNormalization,
     speechServicesAuthorizationToken,
     speechServicesSubscriptionKey,
-    speechSynthesisDeploymentId
+    speechSynthesisDeploymentId,
+    speechSynthesisOutputFormat
   } = yield select();
 
   if (ponyfillType === 'browser') {
@@ -92,6 +95,7 @@ function* setPonyfillSaga() {
       region,
       speechRecognitionEndpointId,
       speechSynthesisDeploymentId,
+      speechSynthesisOutputFormat,
       textNormalization
     };
 


### PR DESCRIPTION
> Fix #48.

## Description

Add `speechSynthesisOutputFormat` and clean up `README.md`.

## Changelog

- Speech synthesis: Fix [#48](https://github.com/compulim/web-speech-cognitive-services/issues/48), support output format through `outputFormat` option, in PR [#49](https://github.com/compulim/web-speech-cognitive-services/pull/49)
