### PR TITLE
Add `enableTelemetry` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Speech synthesis: Fix [#28](https://github.com/compulim/web-speech-cognitive-services/issues/28), support custom voice font, in PR [#41](https://github.com/compulim/web-speech-cognitive-services/pull/41)
    - Use option `speechSynthesisDeploymentId`
 - Speech synthesis: Fix [#48](https://github.com/compulim/web-speech-cognitive-services/issues/48), support output format through `outputFormat` option, in PR [#49](https://github.com/compulim/web-speech-cognitive-services/pull/49)
+- `*`: Fix [#47](https://github.com/compulim/web-speech-cognitive-services/issues/47), add `enableTelemetry` option for disabling collecting telemetry data in Speech SDK, in PR [#51](https://github.com/compulim/web-speech-cognitive-services/pull/51)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,11 @@ The following list all options supported by the adapter.
       </td>
     </tr>
     <tr>
+      <td><code>enableTelemetry</code></td>
+      <td><code>undefined</code></td>
+      <td>Pass-through option to enable or disable telemetry for Speech SDK recognizer as <a href="https://github.com/Microsoft/cognitive-services-speech-sdk-js#data--telemetry">outlined in Speech SDK</a>. This adapter does not collect any telemetry.<br /><br />By default, Speech SDK will collect telemetry unless this is set to <code>false</code>.</td>
+    </tr>
+    <tr>
       <td><code>ponyfill.AudioContext:&nbsp;<a href="https://developer.mozilla.org/en-US/docs/Web/API/AudioContext">AudioContext</a></code></td>
       <td><code>window.AudioContext&nbsp;||</code><br /><code>window.webkitAudioContext</code></td>
       <td>

--- a/packages/component/src/SpeechServices/SpeechToText/createSpeechRecognitionPonyfill.js
+++ b/packages/component/src/SpeechServices/SpeechToText/createSpeechRecognitionPonyfill.js
@@ -75,6 +75,7 @@ function cognitiveServicesAsyncToPromise(fn) {
 export default ({
   audioConfig = AudioConfig.fromDefaultMicrophoneInput(),
   authorizationToken,
+  enableTelemetry,
   referenceGrammars,
   region = 'westus',
   speechRecognitionEndpointId,
@@ -90,6 +91,8 @@ export default ({
 
     return {};
   }
+
+  SpeechRecognizer.enableTelemetry(enableTelemetry);
 
   class SpeechRecognition extends DOMEventEmitter {
     constructor() {

--- a/packages/component/src/SpeechServices/SpeechToText/createSpeechRecognitionPonyfill.test.js
+++ b/packages/component/src/SpeechServices/SpeechToText/createSpeechRecognitionPonyfill.test.js
@@ -107,6 +107,10 @@ const MOCK_SPEECH_SDK = {
   }
 };
 
+beforeEach(() => {
+  MOCK_SPEECH_SDK.SpeechRecognizer.enableTelemetry = jest.fn();
+});
+
 function createRecognizingEvent(text, { duration = 1, offset = 0 } = {}) {
   return {
     result: {
@@ -1184,5 +1188,39 @@ describe('SpeechRecognition with Custom Speech', () => {
     speechRecognition.start();
 
     expect(recognizer.speechConfig).toHaveProperty('endpointId', '12345678-1234-5678-abcd-12345678abcd');
+  });
+});
+
+describe('SpeechRecognition with telemetry', () => {
+  test('disabled', async () => {
+    const { default: createSpeechRecognitionPonyfill } = require('./createSpeechRecognitionPonyfill');
+    const { SpeechRecognition } = createSpeechRecognitionPonyfill({
+      enableTelemetry: false,
+      region: 'westus',
+      subscriptionKey: 'SUBSCRIPTION_KEY'
+    });
+
+    const speechRecognition = new SpeechRecognition();
+
+    speechRecognition.start();
+
+    expect(MOCK_SPEECH_SDK.SpeechRecognizer.enableTelemetry).toHaveBeenCalledTimes(1);
+    expect(MOCK_SPEECH_SDK.SpeechRecognizer.enableTelemetry).toHaveBeenCalledWith(false);
+  });
+
+  test('enabled', async () => {
+    const { default: createSpeechRecognitionPonyfill } = require('./createSpeechRecognitionPonyfill');
+    const { SpeechRecognition } = createSpeechRecognitionPonyfill({
+      enableTelemetry: true,
+      region: 'westus',
+      subscriptionKey: 'SUBSCRIPTION_KEY'
+    });
+
+    const speechRecognition = new SpeechRecognition();
+
+    speechRecognition.start();
+
+    expect(MOCK_SPEECH_SDK.SpeechRecognizer.enableTelemetry).toHaveBeenCalledTimes(1);
+    expect(MOCK_SPEECH_SDK.SpeechRecognizer.enableTelemetry).toHaveBeenCalledWith(true);
   });
 });

--- a/packages/playground/src/UI/PonyfillSelector.js
+++ b/packages/playground/src/UI/PonyfillSelector.js
@@ -1,38 +1,51 @@
 import { useDispatch, useSelector } from 'react-redux';
+import classNames from 'classnames';
 import React, { useCallback } from 'react';
 
 import Select, { Option } from '../Bootstrap/Select';
+import setEnableTelemetry from '../data/actions/setEnableTelemetry';
 import setPonyfillType from '../data/actions/setPonyfillType';
 
 const PonyfillSelector = () => {
-  const { browserSupportedSpeechRecognition, ponyfillType } = useSelector(({
-    browserSupportedSpeechRecognition, ponyfillType
+  const { browserSupportedSpeechRecognition, ponyfillType, enableTelemetry } = useSelector(({
+    browserSupportedSpeechRecognition, ponyfillType, enableTelemetry
   }) => ({
-    browserSupportedSpeechRecognition, ponyfillType
+    browserSupportedSpeechRecognition, ponyfillType, enableTelemetry
   }));
 
   const dispatch = useDispatch();
+  const dispatchSetEnableTelemetry = useCallback(() => dispatch(setEnableTelemetry(!enableTelemetry)), [dispatch, enableTelemetry]);
   const dispatchSetPonyfillType = useCallback(value => dispatch(setPonyfillType(value)), [dispatch]);
 
   return (
-    <Select
-      onChange={ dispatchSetPonyfillType }
-      value={ ponyfillType }
-    >
-      <Option
-        disabled={ !browserSupportedSpeechRecognition }
-        text="Browser"
-        value="browser"
-      />
-      <Option
-        text="Bing Speech"
-        value="bingspeech"
-      />
-      <Option
-        text="Speech Services"
-        value="speechservices"
-      />
-    </Select>
+    <div className="input-group">
+      <Select
+        onChange={ dispatchSetPonyfillType }
+        value={ ponyfillType }
+      >
+        <Option
+          disabled={ !browserSupportedSpeechRecognition }
+          text="Browser"
+          value="browser"
+        />
+        <Option
+          text="Bing Speech"
+          value="bingspeech"
+        />
+        <Option
+          text="Speech Services"
+          value="speechservices"
+        />
+      </Select>
+      <div className="input-group-append">
+        <button
+          className={ classNames('btn btn-outline-secondary', { active: enableTelemetry }) }
+          disabled={ ponyfillType !== 'speechservices' }
+          onClick={ dispatchSetEnableTelemetry }
+          type="button"
+        >Telemetry</button>
+      </div>
+    </div>
   );
 }
 

--- a/packages/playground/src/data/actions/setEnableTelemetry.js
+++ b/packages/playground/src/data/actions/setEnableTelemetry.js
@@ -1,0 +1,10 @@
+const SET_ENABLE_TELEMETRY = 'SET_ENABLE_TELEMETRY';
+
+export default function setEnableTelemetry(enableTelemetry) {
+  return {
+    type: SET_ENABLE_TELEMETRY,
+    payload: { enableTelemetry }
+  };
+}
+
+export { SET_ENABLE_TELEMETRY }

--- a/packages/playground/src/data/reducer.js
+++ b/packages/playground/src/data/reducer.js
@@ -3,6 +3,7 @@ import { combineReducers } from 'redux';
 import bingSpeechAuthorizationToken from './reducers/bingSpeechAuthorizationToken';
 import bingSpeechSubscriptionKey from './reducers/bingSpeechSubscriptionKey';
 import browserSupportedSpeechRecognition from './reducers/browserSupportedSpeechRecognition';
+import enableTelemetry from './reducers/enableTelemetry';
 import navPane from './reducers/navPane';
 import onDemandAuthorizationToken from './reducers/onDemandAuthorizationToken';
 import ponyfill from './reducers/ponyfill';
@@ -31,6 +32,7 @@ export default combineReducers({
   bingSpeechAuthorizationToken,
   bingSpeechSubscriptionKey,
   browserSupportedSpeechRecognition,
+  enableTelemetry,
   navPane,
   onDemandAuthorizationToken,
   ponyfill,

--- a/packages/playground/src/data/reducers/enableTelemetry.js
+++ b/packages/playground/src/data/reducers/enableTelemetry.js
@@ -1,0 +1,9 @@
+import { SET_ENABLE_TELEMETRY } from '../actions/setEnableTelemetry';
+
+export default function (state = true, { payload, type }) {
+  if (type === SET_ENABLE_TELEMETRY) {
+    return payload.enableTelemetry;
+  }
+
+  return state;
+}

--- a/packages/playground/src/data/sagas/setPonyfill.js
+++ b/packages/playground/src/data/sagas/setPonyfill.js
@@ -7,6 +7,7 @@ import {
 
 import { SET_BING_SPEECH_AUTHORIZATION_TOKEN } from '../actions/setBingSpeechAuthorizationToken';
 import { SET_BING_SPEECH_SUBSCRIPTION_KEY } from '../actions/setBingSpeechSubscriptionKey';
+import { SET_ENABLE_TELEMETRY } from '../actions/setEnableTelemetry';
 import { SET_ON_DEMAND_AUTHORIZATION_TOKEN } from '../actions/setOnDemandAuthorizationToken';
 import { SET_PONYFILL_TYPE } from '../actions/setPonyfillType';
 import { SET_REGION } from '../actions/setRegion';
@@ -29,6 +30,7 @@ export default function* () {
     ({ type }) =>
       type === SET_BING_SPEECH_AUTHORIZATION_TOKEN
       || type === SET_BING_SPEECH_SUBSCRIPTION_KEY
+      || type === SET_ENABLE_TELEMETRY
       || type === SET_PONYFILL_TYPE
       || type === SET_REGION
       || type === SET_SPEECH_RECOGNITION_REFERENCE_GRAMMARS
@@ -47,6 +49,7 @@ function* setPonyfillSaga() {
   const {
     bingSpeechAuthorizationToken,
     bingSpeechSubscriptionKey,
+    enableTelemetry,
     onDemandAuthorizationToken,
     ponyfillType,
     region,
@@ -91,6 +94,7 @@ function* setPonyfillSaga() {
     yield put(setPonyfill(ponyfill));
   } else {
     const options = {
+      enableTelemetry,
       referenceGrammars,
       region,
       speechRecognitionEndpointId,


### PR DESCRIPTION
## Changelog

### Added

- `*`: Fix [#47](https://github.com/compulim/web-speech-cognitive-services/issues/47), add `enableTelemetry` option for disabling collecting telemetry data in Speech SDK, in PR [#51](https://github.com/compulim/web-speech-cognitive-services/pull/51)
