### PR TITLE
Support stop with partial recognized speech

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `*`: Fix [#47](https://github.com/compulim/web-speech-cognitive-services/issues/47), add `enableTelemetry` option for disabling collecting telemetry data in Speech SDK, in PR [#51](https://github.com/compulim/web-speech-cognitive-services/pull/51)
 - `*`: Fix [#53](https://github.com/compulim/web-speech-cognitive-services/issues/53), added ESLint, in PR [#54](https://github.com/compulim/web-speech-cognitive-services/pull/54)
 - Speech synthesis: Fix [#39](https://github.com/compulim/web-speech-cognitive-services/issues/39), support SSML utterance, in PR [#57](https://github.com/compulim/web-speech-cognitive-services/pull/57)
+- Speech recognition: Fix [#59](https://github.com/compulim/web-speech-cognitive-services/issues/59), support `stop()` function by finalizing partial speech, in PR [#60](https://github.com/compulim/web-speech-cognitive-services/pull/60)
 
 ### Changed
 

--- a/packages/component/src/SpeechServices/SpeechToText/__snapshots__/createSpeechRecognitionPonyfill.test.js.snap
+++ b/packages/component/src/SpeechServices/SpeechToText/__snapshots__/createSpeechRecognitionPonyfill.test.js.snap
@@ -40,7 +40,7 @@ Array [
 ]
 `;
 
-exports[`SpeechRecognition in continuous mode stop after recognized 2 speeches 1`] = `
+exports[`SpeechRecognition in continuous mode stop after recognized 1 speech and 1 ongoing 1`] = `
 Array [
   "cognitiveservices:audioSourceReady",
   "webspeech:start",
@@ -52,9 +52,9 @@ Array [
   "webspeech:result ['hello']",
   "cognitiveservices:recognized",
   "webspeech:result ['Hello.' (isFinal)]",
+  "cognitiveservices:stop",
   "cognitiveservices:recognized",
   "webspeech:result ['Hello.' (isFinal), 'World.' (isFinal)]",
-  "cognitiveservices:stop",
   "cognitiveservices:audioSourceOff",
   "webspeech:speechend",
   "webspeech:soundend",
@@ -97,6 +97,7 @@ Array [
   "webspeech:speechend",
   "webspeech:soundend",
   "webspeech:audioend",
+  "webspeech:error { error: 'no-speech' }",
   "webspeech:end",
 ]
 `;

--- a/packages/component/src/SpeechServices/SpeechToText/createSpeechRecognitionPonyfill.test.js
+++ b/packages/component/src/SpeechServices/SpeechToText/createSpeechRecognitionPonyfill.test.js
@@ -715,6 +715,7 @@ describe('SpeechRecognition', () => {
       // webspeech:speechend
       // webspeech:soundend
       // webspeech:audioend
+      // webspeech:error { error: 'no-speech' }
       // webspeech:end
 
       await endEventEmitted;
@@ -765,7 +766,7 @@ describe('SpeechRecognition', () => {
       expect(toSnapshot(events)).toMatchSnapshot();
     });
 
-    test('stop after recognized 2 speeches', async () => {
+    test('stop after recognized 1 speech and 1 ongoing', async () => {
       speechRecognition.start();
       speechRecognition.continuous = true;
       speechRecognition.interimResults = true;
@@ -796,14 +797,14 @@ describe('SpeechRecognition', () => {
       // cognitiveservices:recognized
       // webspeech:result ['Hello.' (isFinal)]
 
+      speechRecognition.stop();
+
+      // cognitiveservices:stop
+
       recognizer.recognized(this, createRecognizedEvent('World.'));
 
       // cognitiveservices:recognized
       // webspeech:result ['Hello.' (isFinal), 'World.' (isFinal)]
-
-      speechRecognition.stop();
-
-      // cognitiveservices:stop
 
       recognizer.audioConfig.emitEvent('AudioSourceOffEvent');
 


### PR DESCRIPTION
> Fix #59.

This is the last technically-feasible feature to make Cognitive Services Speech Services to be on-par with the W3C standard.

## Changelog

### Added

- Speech recognition: Fix [#59](https://github.com/compulim/web-speech-cognitive-services/issues/59), support `stop()` function by finalizing partial speech, in PR [#60](https://github.com/compulim/web-speech-cognitive-services/pull/60)
