### PR TITLE
Fix defineEventProperty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added version number as `<meta>` tag, in PR [#20](https://github.com/compulim/web-speech-cognitive-services/pull/20)
 - Added bundle distribution thru https://unpkg.com/web-speech-cognitive-services@latest/umd/, in PR [#21](https://github.com/compulim/web-speech-cognitive-services/pull/21)
 - Bumped to [microsoft-cognitiveservices-speech-sdk@1.6.0](https://www.npmjs.com/package/microsoft-cognitiveservices-speech-sdk), in PR [#22](https://github.com/compulim/web-speech-cognitive-services/pull/22)
-- Fix [#55](https://github.com/compulim/web-speech-cognitive-services/issues/55). Moves to [WHATWG `EventTarget` interface](https://dom.spec.whatwg.org/#interface-eventtarget), in PR [#56](https://github.com/compulim/web-speech-cognitive-services/pulls/56)
+- Fix [#55](https://github.com/compulim/web-speech-cognitive-services/issues/55) and [#63](https://github.com/compulim/web-speech-cognitive-services/issues/63). Moves to [WHATWG `EventTarget` interface](https://dom.spec.whatwg.org/#interface-eventtarget), in PR [#56](https://github.com/compulim/web-speech-cognitive-services/pulls/56) and PR [#64](https://github.com/compulim/web-speech-cognitive-services/pulls/64)
 
 ### Fixed
 

--- a/packages/component/src/SpeechServices/SpeechToText/createSpeechRecognitionPonyfill.js
+++ b/packages/component/src/SpeechServices/SpeechToText/createSpeechRecognitionPonyfill.js
@@ -492,23 +492,18 @@ export default ({
     stop() {}
   }
 
-  defineEventAttribute(
-    SpeechRecognition.prototype,
-    [
-      'audioend',
-      'audiostart',
-      'cognitiveservices',
-      'end',
-      'error',
-      'nomatch',
-      'result',
-      'soundend',
-      'soundstart',
-      'speechend',
-      'speechstart',
-      'start'
-    ]
-  );
+  defineEventAttribute(SpeechRecognition.prototype, 'audioend');
+  defineEventAttribute(SpeechRecognition.prototype, 'audiostart');
+  defineEventAttribute(SpeechRecognition.prototype, 'cognitiveservices');
+  defineEventAttribute(SpeechRecognition.prototype, 'end');
+  defineEventAttribute(SpeechRecognition.prototype, 'error');
+  defineEventAttribute(SpeechRecognition.prototype, 'nomatch');
+  defineEventAttribute(SpeechRecognition.prototype, 'result');
+  defineEventAttribute(SpeechRecognition.prototype, 'soundend');
+  defineEventAttribute(SpeechRecognition.prototype, 'soundstart');
+  defineEventAttribute(SpeechRecognition.prototype, 'speechend');
+  defineEventAttribute(SpeechRecognition.prototype, 'speechstart');
+  defineEventAttribute(SpeechRecognition.prototype, 'start');
 
   return {
     SpeechGrammarList,

--- a/packages/component/src/SpeechServices/TextToSpeech/SpeechSynthesisUtterance.js
+++ b/packages/component/src/SpeechServices/TextToSpeech/SpeechSynthesisUtterance.js
@@ -5,6 +5,7 @@ import EventAsPromise from 'event-as-promise';
 
 import fetchSpeechData from './fetchSpeechData';
 import SpeechSynthesisEvent from './SpeechSynthesisEvent';
+import SpeechSynthesisVoice from './SpeechSynthesisVoice';
 import subscribeEvent from './subscribeEvent';
 
 function asyncDecodeAudioData(audioContext, arrayBuffer) {
@@ -129,15 +130,10 @@ export default class extends EventTarget {
   }
 }
 
-defineEventAttribute(
-  SpeechSynthesisUtterance.prototype,
-  [
-    'boundary',
-    'end',
-    'error',
-    'mark',
-    'pause',
-    'resume',
-    'start'
-  ]
-);
+defineEventAttribute(SpeechSynthesisUtterance.prototype, 'boundary');
+defineEventAttribute(SpeechSynthesisUtterance.prototype, 'end');
+defineEventAttribute(SpeechSynthesisUtterance.prototype, 'error');
+defineEventAttribute(SpeechSynthesisUtterance.prototype, 'mark');
+defineEventAttribute(SpeechSynthesisUtterance.prototype, 'pause');
+defineEventAttribute(SpeechSynthesisUtterance.prototype, 'resume');
+defineEventAttribute(SpeechSynthesisUtterance.prototype, 'start');


### PR DESCRIPTION
> Fix #63.

## Changelog

### Changed

- Fix [#55](https://github.com/compulim/web-speech-cognitive-services/issues/55) and [#63](https://github.com/compulim/web-speech-cognitive-services/issues/63). Moves to [WHATWG `EventTarget` interface](https://dom.spec.whatwg.org/#interface-eventtarget), in PR [#56](https://github.com/compulim/web-speech-cognitive-services/pulls/56) and PR [#64](https://github.com/compulim/web-speech-cognitive-services/pulls/64)
