### PR TITLE
Default telemetry to true to honor Speech SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Speech synthesis: Fix [#28](https://github.com/compulim/web-speech-cognitive-services/issues/28), support custom voice font, in PR [#41](https://github.com/compulim/web-speech-cognitive-services/pull/41)
    - Use option `speechSynthesisDeploymentId`
 - Speech synthesis: Fix [#48](https://github.com/compulim/web-speech-cognitive-services/issues/48), support output format through `outputFormat` option, in PR [#49](https://github.com/compulim/web-speech-cognitive-services/pull/49)
-- `*`: Fix [#47](https://github.com/compulim/web-speech-cognitive-services/issues/47), add `enableTelemetry` option for disabling collecting telemetry data in Speech SDK, in PR [#51](https://github.com/compulim/web-speech-cognitive-services/pull/51)
+- `*`: Fix [#47](https://github.com/compulim/web-speech-cognitive-services/issues/47), add `enableTelemetry` option for disabling collecting telemetry data in Speech SDK, in PR [#51](https://github.com/compulim/web-speech-cognitive-services/pull/51) and PR [#66](https://github.com/compulim/web-speech/cognitive-services/pull/66)
 - `*`: Fix [#53](https://github.com/compulim/web-speech-cognitive-services/issues/53), added ESLint, in PR [#54](https://github.com/compulim/web-speech-cognitive-services/pull/54)
 - Speech synthesis: Fix [#39](https://github.com/compulim/web-speech-cognitive-services/issues/39), support SSML utterance, in PR [#57](https://github.com/compulim/web-speech-cognitive-services/pull/57)
 - Speech recognition: Fix [#59](https://github.com/compulim/web-speech-cognitive-services/issues/59), support `stop()` function by finalizing partial speech, in PR [#60](https://github.com/compulim/web-speech-cognitive-services/pull/60)

--- a/packages/component/src/SpeechServices/SpeechToText/createSpeechRecognitionPonyfill.js
+++ b/packages/component/src/SpeechServices/SpeechToText/createSpeechRecognitionPonyfill.js
@@ -144,7 +144,7 @@ export default ({
     })
   );
 
-  // If enableTelemetry is set to null or non-deterministic, we will default to true.
+  // If enableTelemetry is set to null or non-boolean, we will default to true.
   SpeechRecognizer.enableTelemetry(enableTelemetry !== false);
 
   class SpeechRecognition extends EventTarget {

--- a/packages/component/src/SpeechServices/SpeechToText/createSpeechRecognitionPonyfill.js
+++ b/packages/component/src/SpeechServices/SpeechToText/createSpeechRecognitionPonyfill.js
@@ -91,7 +91,11 @@ class SpeechRecognitionEvent {
 export default ({
   audioConfig = AudioConfig.fromDefaultMicrophoneInput(),
   authorizationToken,
-  enableTelemetry,
+
+  // We set telemetry to true to honor the default telemetry settings of Speech SDK
+  // https://github.com/Microsoft/cognitive-services-speech-sdk-js#data--telemetry
+  enableTelemetry = true,
+
   referenceGrammars,
   region = 'westus',
   speechRecognitionEndpointId,
@@ -140,7 +144,8 @@ export default ({
     })
   );
 
-  SpeechRecognizer.enableTelemetry(enableTelemetry);
+  // If enableTelemetry is set to null or non-deterministic, we will default to true.
+  SpeechRecognizer.enableTelemetry(enableTelemetry !== false);
 
   class SpeechRecognition extends EventTarget {
     constructor() {


### PR DESCRIPTION
> Fix #65.

## Description

Recent PR #51 did not enable telemetry if it is set to `undefined` or non-boolean.

This is for honoring Speech SDK default settings of enable telemetry.

## Changelog

### Added

- `*`: Fix [#47](https://github.com/compulim/web-speech-cognitive-services/issues/47), add `enableTelemetry` option for disabling collecting telemetry data in Speech SDK, in PR [#51](https://github.com/compulim/web-speech-cognitive-services/pull/51) and PR [#66](https://github.com/compulim/web-speech/cognitive-services/pull/66)
