### PR TITLE
Fetch custom voice list when using subscription key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
    - When creating the ponyfill, pass it as an array to `referenceGrammars` options
 - Speech recognition: Fix [#27](https://github.com/compulim/web-speech-cognitive-services/issues/27), support custom speech, in PR [#41](https://github.com/compulim/web-speech-cognitive-services/pull/41)
    - Use option `speechRecognitionEndpointId`
-- Speech synthesis: Fix [#28](https://github.com/compulim/web-speech-cognitive-services/issues/28), support custom voice font, in PR [#41](https://github.com/compulim/web-speech-cognitive-services/pull/41) and PR [#67](https://github.com/compulim/web-speech-cognitive-services/pull/67)
+- Speech synthesis: Fix [#28](https://github.com/compulim/web-speech-cognitive-services/issues/28) and [#62](https://github.com/compulim/web-speech-cognitive-services/issues/62), support custom voice font, in PR [#41](https://github.com/compulim/web-speech-cognitive-services/pull/41) and PR [#67](https://github.com/compulim/web-speech-cognitive-services/pull/67)
    - Use option `speechSynthesisDeploymentId`
    - Voice list is only fetch when using subscription key
 - Speech synthesis: Fix [#48](https://github.com/compulim/web-speech-cognitive-services/issues/48), support output format through `outputFormat` option, in PR [#49](https://github.com/compulim/web-speech-cognitive-services/pull/49)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
    - When creating the ponyfill, pass it as an array to `referenceGrammars` options
 - Speech recognition: Fix [#27](https://github.com/compulim/web-speech-cognitive-services/issues/27), support custom speech, in PR [#41](https://github.com/compulim/web-speech-cognitive-services/pull/41)
    - Use option `speechRecognitionEndpointId`
-- Speech synthesis: Fix [#28](https://github.com/compulim/web-speech-cognitive-services/issues/28), support custom voice font, in PR [#41](https://github.com/compulim/web-speech-cognitive-services/pull/41)
+- Speech synthesis: Fix [#28](https://github.com/compulim/web-speech-cognitive-services/issues/28), support custom voice font, in PR [#41](https://github.com/compulim/web-speech-cognitive-services/pull/41) and PR [#67](https://github.com/compulim/web-speech-cognitive-services/pull/67)
    - Use option `speechSynthesisDeploymentId`
+   - Voice list is only fetch when using subscription key
 - Speech synthesis: Fix [#48](https://github.com/compulim/web-speech-cognitive-services/issues/48), support output format through `outputFormat` option, in PR [#49](https://github.com/compulim/web-speech-cognitive-services/pull/49)
 - `*`: Fix [#47](https://github.com/compulim/web-speech-cognitive-services/issues/47), add `enableTelemetry` option for disabling collecting telemetry data in Speech SDK, in PR [#51](https://github.com/compulim/web-speech-cognitive-services/pull/51) and PR [#66](https://github.com/compulim/web-speech/cognitive-services/pull/66)
 - `*`: Fix [#53](https://github.com/compulim/web-speech-cognitive-services/issues/53), added ESLint, in PR [#54](https://github.com/compulim/web-speech-cognitive-services/pull/54)

--- a/packages/component/src/SpeechServices/TextToSpeech/fetchCustomVoices.js
+++ b/packages/component/src/SpeechServices/TextToSpeech/fetchCustomVoices.js
@@ -1,0 +1,31 @@
+/* eslint no-magic-numbers: ["error", { "ignore": [0, 1, -1] }] */
+
+import SpeechSynthesisVoice from './SpeechSynthesisVoice';
+
+async function fetchEndpoint({ deploymentId, region, subscriptionKey }) {
+  // Although encodeURI on a hostname doesn't work as expected for hostname, at least, it will fail peacefully.
+
+  const res = await fetch(
+    `https://${ encodeURI(region) }.cris.ai/api/texttospeech/v2.0/endpoints/${ encodeURIComponent(deploymentId) }`,
+    {
+      headers: {
+        accept: 'application/json',
+        'ocp-apim-subscription-key': subscriptionKey
+      }
+    }
+  );
+
+  if (!res.ok) {
+    throw new Error('Failed to fetch custom voices');
+  }
+
+  return await res.json();
+}
+
+export default async function ({ deploymentId, region, subscriptionKey }) {
+  const { models } = await fetchEndpoint({ deploymentId, region, subscriptionKey });
+
+  return models
+    .map(({ properties: { Gender: gender }, locale: lang, name: voiceURI }) => new SpeechSynthesisVoice({ gender, lang, voiceURI }))
+    .sort(({ name: x }, { name: y }) => x > y ? 1 : x < y ? -1 : 0);
+}

--- a/packages/component/src/SpeechServices/TextToSpeech/fetchVoices.js
+++ b/packages/component/src/SpeechServices/TextToSpeech/fetchVoices.js
@@ -2,14 +2,11 @@
 
 import SpeechSynthesisVoice from './SpeechSynthesisVoice';
 
-export default async function ({ authorizationToken, deploymentId, region }) {
-  // Although encodeURI on a hostname doesn't work as expected, at least, it will fail peacefully.
+export default async function ({ authorizationToken, region }) {
+  // Although encodeURI on a hostname doesn't work as expected for hostname, at least, it will fail peacefully.
 
   const res = await fetch(
-    deploymentId ?
-      `https://${ encodeURI(region) }.voice.speech.microsoft.com/cognitiveservices/voices/list?deploymentId=${ encodeURIComponent(deploymentId) }`
-    :
-      `https://${ encodeURI(region) }.tts.speech.microsoft.com/cognitiveservices/voices/list`,
+    `https://${ encodeURI(region) }.tts.speech.microsoft.com/cognitiveservices/voices/list`,
     {
       headers: {
         authorization: `Bearer ${ authorizationToken }`,


### PR DESCRIPTION
> Fix #62.

## Description

Custom voice list can only be fetch if using subscription key. A warning has been added to remind developers about the behavioral differences when using a subscription key and an authorization token.

## Changelog

### Added

- Speech synthesis: Fix [#28](https://github.com/compulim/web-speech-cognitive-services/issues/28) and [#62](https://github.com/compulim/web-speech-cognitive-services/issues/62), support custom voice font, in PR [#41](https://github.com/compulim/web-speech-cognitive-services/pull/41) and PR [#67](https://github.com/compulim/web-speech-cognitive-services/pull/67)
   - Voice list is only fetch when using subscription key
