### PR TITLE
Add warning when using subscription key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `*`: Fix [#53](https://github.com/compulim/web-speech-cognitive-services/issues/53), added ESLint, in PR [#54](https://github.com/compulim/web-speech-cognitive-services/pull/54)
 - Speech synthesis: Fix [#39](https://github.com/compulim/web-speech-cognitive-services/issues/39), support SSML utterance, in PR [#57](https://github.com/compulim/web-speech-cognitive-services/pull/57)
 - Speech recognition: Fix [#59](https://github.com/compulim/web-speech-cognitive-services/issues/59), support `stop()` function by finalizing partial speech, in PR [#60](https://github.com/compulim/web-speech-cognitive-services/pull/60)
+- Fix [#67](https://github.com/compulim/web-speech-cognitive-services/issues/67), add warning when using subscription key instead of authorization token, in PR [#69](https://github.com/compulim/web-speech-cognitive-services/pull/69)
 
 ### Changed
 

--- a/packages/component/src/SpeechServices.js
+++ b/packages/component/src/SpeechServices.js
@@ -4,10 +4,18 @@ import createSpeechRecognitionPonyfill from './SpeechServices/SpeechToText';
 import createSpeechSynthesisPonyfill from './SpeechServices/TextToSpeech';
 import fetchAuthorizationToken from './SpeechServices/fetchAuthorizationToken';
 
-export default function createSpeechServicesPonyfill(...args) {
+let shouldWarnOnSubscriptionKey = true;
+
+export default function createSpeechServicesPonyfill(options = {}, ...args) {
+  if (shouldWarnOnSubscriptionKey && options.subscriptionKey) {
+    console.warn('web-speech-cognitive-services: In production environment, subscription key should not be used, authorization token should be used instead.');
+
+    shouldWarnOnSubscriptionKey = false;
+  }
+
   const ponyfill = {
-    ...createSpeechRecognitionPonyfill(...args),
-    ...createSpeechSynthesisPonyfill(...args),
+    ...createSpeechRecognitionPonyfill(options, ...args),
+    ...createSpeechSynthesisPonyfill(options, ...args),
   };
 
   return {

--- a/packages/component/src/SpeechServices/SpeechToText/createSpeechRecognitionPonyfill.js
+++ b/packages/component/src/SpeechServices/SpeechToText/createSpeechRecognitionPonyfill.js
@@ -103,11 +103,11 @@ export default ({
   textNormalization = 'display'
 } = {}) => {
   if (!authorizationToken && !subscriptionKey) {
-    console.warn('Either authorizationToken or subscriptionKey must be specified');
+    console.warn('web-speech-cognitive-services: Either authorizationToken or subscriptionKey must be specified');
 
     return {};
   } else if (!window.navigator.mediaDevices || !window.navigator.mediaDevices.getUserMedia) {
-    console.warn('This browser does not support WebRTC and it will not work with Cognitive Services Speech Services.');
+    console.warn('web-speech-cognitive-services: This browser does not support WebRTC and it will not work with Cognitive Services Speech Services.');
 
     return {};
   }

--- a/packages/component/src/SpeechServices/TextToSpeech/createSpeechSynthesisPonyfill.js
+++ b/packages/component/src/SpeechServices/TextToSpeech/createSpeechSynthesisPonyfill.js
@@ -28,11 +28,11 @@ export default ({
   subscriptionKey
 }) => {
   if (!authorizationToken && !subscriptionKey) {
-    console.warn('Either authorization token or subscription key must be specified');
+    console.warn('web-speech-cognitive-services: Either authorization token or subscription key must be specified');
 
     return {};
   } else if (!ponyfill.AudioContext) {
-    console.warn('This browser does not support Web Audio and it will not work with Cognitive Services Speech Services.');
+    console.warn('web-speech-cognitive-services: This browser does not support Web Audio and it will not work with Cognitive Services Speech Services.');
 
     return {};
   }


### PR DESCRIPTION
> Fix #67.

## Description

## Changelog

When using subscription key, we should give a warning in the console and say authorization token should be used instead of subscription key in production environment.

### Added

- Fix [#67](https://github.com/compulim/web-speech-cognitive-services/issues/67), add warning when using subscription key instead of authorization token, in PR [#69](https://github.com/compulim/web-speech-cognitive-services/pull/69)
