### PR TITLE
Get authorization token for every synthesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Speech synthesis: Fix [#39](https://github.com/compulim/web-speech-cognitive-services/issues/39), support SSML utterance, in PR [#57](https://github.com/compulim/web-speech-cognitive-services/pull/57)
 - Speech recognition: Fix [#59](https://github.com/compulim/web-speech-cognitive-services/issues/59), support `stop()` function by finalizing partial speech, in PR [#60](https://github.com/compulim/web-speech-cognitive-services/pull/60)
 - Fix [#67](https://github.com/compulim/web-speech-cognitive-services/issues/67), add warning when using subscription key instead of authorization token, in PR [#69](https://github.com/compulim/web-speech-cognitive-services/pull/69)
+- Fix [#70](https://github.com/compulim/web-speech-cognitive-services/issues/70), fetch authorization token before every synthesis, in PR [#71](https://github.com/compulim/web-speech-cognitive-services/pull/71)
 
 ### Changed
 

--- a/packages/component/src/SpeechServices/TextToSpeech/SpeechSynthesisUtterance.js
+++ b/packages/component/src/SpeechServices/TextToSpeech/SpeechSynthesisUtterance.js
@@ -80,14 +80,14 @@ class SpeechSynthesisUtterance extends EventTarget {
   set volume(value) { this._volume = value; }
 
   async preload({
-    authorizationTokenPromise,
     deploymentId,
+    getAuthorizationToken,
     outputFormat,
     region
   }) {
     this.arrayBufferPromise = fetchSpeechData({
-      authorizationTokenPromise,
       deploymentId,
+      getAuthorizationToken,
       lang: this.lang || window.navigator.language,
       outputFormat,
       pitch: this.pitch,

--- a/packages/component/src/SpeechServices/TextToSpeech/createSpeechSynthesisPonyfill.js
+++ b/packages/component/src/SpeechServices/TextToSpeech/createSpeechSynthesisPonyfill.js
@@ -46,17 +46,20 @@ export default ({
     )
   );
 
-  const getAuthorizationTokenPromise =
-    typeof authorizationToken === 'function' ?
-      authorizationToken()
-    : authorizationToken ?
-      authorizationToken
-    :
-      fetchMemoizedAuthorizationToken({
-        now: Date.now,
-        region,
-        subscriptionKey
-      });
+  const getAuthorizationToken = async () => {
+    return (
+      typeof authorizationToken === 'function' ?
+        await authorizationToken()
+      : authorizationToken ?
+        await authorizationToken
+      :
+        await fetchMemoizedAuthorizationToken({
+          now: Date.now,
+          region,
+          subscriptionKey
+        })
+    );
+  };
 
   class SpeechSynthesis extends EventTarget {
     constructor() {
@@ -93,8 +96,8 @@ export default ({
         utterance.addEventListener('error', reject);
 
         utterance.preload({
-          authorizationTokenPromise: getAuthorizationTokenPromise,
           deploymentId: speechSynthesisDeploymentId,
+          getAuthorizationToken,
           outputFormat: speechSynthesisOutputFormat,
           region
         });
@@ -128,7 +131,7 @@ export default ({
 
         await onErrorResumeNext(async () => {
           const voices = await fetchVoices({
-            authorizationToken: await getAuthorizationTokenPromise,
+            authorizationToken: await getAuthorizationToken(),
             deploymentId: speechSynthesisDeploymentId,
             region
           });

--- a/packages/component/src/SpeechServices/TextToSpeech/fetchSpeechData.js
+++ b/packages/component/src/SpeechServices/TextToSpeech/fetchSpeechData.js
@@ -9,8 +9,8 @@ const SYNTHESIS_CUSTOM_VOICE_URL_TEMPLATE = 'https://{region}.voice.speech.micro
 const SYNTHESIS_URL_TEMPLATE = 'https://{region}.tts.speech.microsoft.com/cognitiveservices/v1';
 
 export default async function ({
-  authorizationTokenPromise,
   deploymentId,
+  getAuthorizationToken,
   lang = DEFAULT_LANGUAGE,
   outputFormat,
   pitch,
@@ -25,7 +25,7 @@ export default async function ({
     return decode(EMPTY_MP3_BASE64);
   }
 
-  const authorizationToken = await authorizationTokenPromise;
+  const authorizationToken = await getAuthorizationToken();
   const ssml = isSSML(text) ? text : buildSSML({ lang, pitch, rate, text, voice, volume });
 
   // Although calling encodeURI on hostname does not actually works, it fails faster and safer.


### PR DESCRIPTION
> Fix #70.

Today, authorization token is only fetched when creating ponyfill.

We should get authorization token just before every synthesis to make sure the token is fresh.