### PR TITLE
Add delayed start to playground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `playground`: Add delayed start to playground for testing speech recognition initiated outside of user gestures, in PR [#78](https://github.com/compulim/web-speech-congitive-services/pull/78)
+
 ## [5.0.1] - 2019-10-25
 
 ### Changed

--- a/packages/component/src/SpeechServices/SpeechToText/createSpeechRecognitionPonyfill.js
+++ b/packages/component/src/SpeechServices/SpeechToText/createSpeechRecognitionPonyfill.js
@@ -100,6 +100,7 @@ export default ({
   region = 'westus',
   speechRecognitionEndpointId,
   subscriptionKey,
+  strictEventOrder = true,
   textNormalization = 'display'
 } = {}) => {
   if (!authorizationToken && !subscriptionKey) {

--- a/packages/playground/src/UI/SpeechRecognitionCommands.js
+++ b/packages/playground/src/UI/SpeechRecognitionCommands.js
@@ -13,6 +13,7 @@ import stopSpeechRecognition from '../data/actions/stopSpeechRecognition';
 import clearSpeechRecognitionEvent from '../data/actions/clearSpeechRecognitionEvent';
 import getPonyfillCapabilities from '../getPonyfillCapabilities';
 import setSpeechRecognitionContinuous from '../data/actions/setSpeechRecognitionContinuous';
+import setSpeechRecognitionDelayedStart from '../data/actions/setSpeechRecognitionDelayedStart';
 import setSpeechRecognitionInterimResults from '../data/actions/setSpeechRecognitionInterimResults';
 import setSpeechRecognitionMaxAlternatives from '../data/actions/setSpeechRecognitionMaxAlternatives';
 import setSpeechRecognitionPhrases from '../data/actions/setSpeechRecognitionPhrases';
@@ -20,8 +21,9 @@ import setSpeechRecognitionReferenceGrammars from '../data/actions/setSpeechReco
 
 const SpeechRecognitionCommands = () => {
   const {
-    empty,
     continuous,
+    delayedStart,
+    empty,
     interimResults,
     maxAlternatives,
     phrases,
@@ -32,14 +34,16 @@ const SpeechRecognitionCommands = () => {
     ponyfillType,
     speechRecognitionEvents,
     speechRecognitionContinuous,
+    speechRecognitionDelayedStart,
     speechRecognitionInterimResults,
     speechRecognitionMaxAlternatives,
     speechRecognitionPhrases,
     speechRecognitionReferenceGrammars,
     speechRecognitionStarted
   }) => ({
-    empty: !speechRecognitionEvents.length,
     continuous: speechRecognitionContinuous,
+    delayedStart: !!speechRecognitionDelayedStart,
+    empty: !speechRecognitionEvents.length,
     interimResults: speechRecognitionInterimResults,
     maxAlternatives: speechRecognitionMaxAlternatives,
     phrases: speechRecognitionPhrases,
@@ -52,9 +56,11 @@ const SpeechRecognitionCommands = () => {
   const dispatchAbortSpeechRecognition = useCallback(() => dispatch(abortSpeechRecognition()), [dispatch]);
   const dispatchClearSpeechRecognitionEvent = useCallback(() => dispatch(clearSpeechRecognitionEvent()), [dispatch]);
   const dispatchSetSpeechRecognitionContinuous = useCallback(() => dispatch(setSpeechRecognitionContinuous(true)), [dispatch]);
+  const dispatchSetSpeechRecognitionDelayedStart = useCallback(() => dispatch(setSpeechRecognitionDelayedStart(true)), [dispatch]);
   const dispatchSetSpeechRecognitionHideInterimResults = useCallback(() => dispatch(setSpeechRecognitionInterimResults(false)), [dispatch]);
   const dispatchSetSpeechRecognitionInteractive = useCallback(() => dispatch(setSpeechRecognitionContinuous(false)), [dispatch]);
   const dispatchSetSpeechRecognitionMaxAlternatives = useCallback(value => dispatch(setSpeechRecognitionMaxAlternatives(+value)), [dispatch]);
+  const dispatchSetSpeechRecognitionNoDelayedStart = useCallback(() => dispatch(setSpeechRecognitionDelayedStart(false)), [dispatch]);
   const dispatchSetSpeechRecognitionPhrases = useCallback(value => dispatch(setSpeechRecognitionPhrases(value)), [dispatch]);
   const dispatchSetSpeechRecognitionReferenceGrammars = useCallback(value => dispatch(setSpeechRecognitionReferenceGrammars(value)), [dispatch]);
   const dispatchSetSpeechRecognitionShowInterimResults = useCallback(() => dispatch(setSpeechRecognitionInterimResults(true)), [dispatch]);
@@ -82,14 +88,26 @@ const SpeechRecognitionCommands = () => {
             {
               continuous ?
                 interimResults ?
-                  'Start in continuous mode with interims'
+                  delayedStart ?
+                    'Delayed start in continuous mode with interims'
+                  :
+                    'Start in continuous mode with interims'
                 :
-                  'Start in continuous mode'
+                  delayedStart ?
+                    'Delayed start in continuous mode'
+                  :
+                    'Start in continuous mode'
               :
                 interimResults ?
-                  'Start with interims'
+                  delayedStart ?
+                    'Delayed start with interims'
+                  :
+                    'Start with interims'
                 :
-                  'Start'
+                  delayedStart ?
+                    'Delayed start'
+                  :
+                    'Start'
             }
           </button>
           <button
@@ -123,6 +141,17 @@ const SpeechRecognitionCommands = () => {
               onClick={ dispatchSetSpeechRecognitionHideInterimResults }
               type="button"
             >Hide interims</button>
+            <div className="dropdown-divider" />
+            <button
+              className="dropdown-item"
+              onClick={ dispatchSetSpeechRecognitionDelayedStart }
+              type="button"
+            >Delayed start</button>
+            <button
+              className="dropdown-item"
+              onClick={ dispatchSetSpeechRecognitionNoDelayedStart }
+              type="button"
+            >No delayed start</button>
           </div>
         </div>
         &nbsp;

--- a/packages/playground/src/data/actions/setSpeechRecognitionDelayedStart.js
+++ b/packages/playground/src/data/actions/setSpeechRecognitionDelayedStart.js
@@ -1,0 +1,10 @@
+const SET_SPEECH_RECOGNITION_DELAYED_START = 'SET_SPEECH_RECOGNITION_DELAYED_START';
+
+export default function (delay) {
+  return {
+    type: SET_SPEECH_RECOGNITION_DELAYED_START,
+    payload: { delay }
+  };
+}
+
+export { SET_SPEECH_RECOGNITION_DELAYED_START }

--- a/packages/playground/src/data/reducer.js
+++ b/packages/playground/src/data/reducer.js
@@ -10,6 +10,7 @@ import ponyfill from './reducers/ponyfill';
 import ponyfillType from './reducers/ponyfillType';
 import region from './reducers/region';
 import speechRecognitionContinuous from './reducers/speechRecognitionContinuous';
+import speechRecognitionDelayedStart from './reducers/speechRecognitionDelayedStart';
 import speechRecognitionEndpointId from './reducers/speechRecognitionEndpointId';
 import speechRecognitionEvents from './reducers/speechRecognitionEvents';
 import speechRecognitionInterimResults from './reducers/speechRecognitionInterimResults';
@@ -39,6 +40,7 @@ export default combineReducers({
   ponyfillType,
   region,
   speechRecognitionContinuous,
+  speechRecognitionDelayedStart,
   speechRecognitionEndpointId,
   speechRecognitionEvents,
   speechRecognitionInterimResults,

--- a/packages/playground/src/data/reducers/speechRecognitionDelayedStart.js
+++ b/packages/playground/src/data/reducers/speechRecognitionDelayedStart.js
@@ -1,0 +1,9 @@
+import { SET_SPEECH_RECOGNITION_DELAYED_START } from '../actions/setSpeechRecognitionDelayedStart';
+
+export default function (state = false, { payload, type }) {
+  if (type === SET_SPEECH_RECOGNITION_DELAYED_START) {
+    state = payload.delay;
+  }
+
+  return state;
+}

--- a/packages/playground/src/data/sagas/speechRecognitionStart.js
+++ b/packages/playground/src/data/sagas/speechRecognitionStart.js
@@ -9,11 +9,21 @@ import { START_SPEECH_RECOGNITION } from '../actions/startSpeechRecognition';
 import setSpeechRecognitionInstance from '../actions/setSpeechRecognitionInstance';
 import stopSpeechRecognition, { STOP_SPEECH_RECOGNITION } from '../actions/stopSpeechRecognition';
 
+function sleep(duration) {
+  return new Promise(resolve => setTimeout(resolve, duration));
+}
+
 export default function* () {
   for (;;) {
     let cancelReason;
 
     yield take(START_SPEECH_RECOGNITION);
+
+    const { speechRecognitionDelayedStart: delayedStart } = yield select();
+
+    if (delayedStart) {
+      yield call(sleep, 2000);
+    }
 
     const task = yield fork(startSpeechRecognition, {
       getCancelReason: () => cancelReason


### PR DESCRIPTION
## Changelog

### Changed

- `playground`: Add delayed start to playground for testing speech recognition initiated outside of user gestures, in PR [#78](https://github.com/compulim/web-speech-congitive-services/pull/78)
