### PR TITLE
Option to disable strict event order

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,0 +1,10 @@
+arrowParens: avoid
+bracketSpacing: true
+jsxBracketSameLine: false
+printWidth: 120
+proseWrap: preserve
+quoteProps: as-needed
+semi: true
+singleQuote: true
+tabWidth: 2
+trailingComma: none

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Speech recognition: Removed extraneous finalized `result` event in continuous mode, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/compulim/web-speech-cognitive-services/pull/XXX)
+
+### Added
+
+- Speech recognition: New `strictEvents` option, default is `true`. When disabled, we will no longer follow observed browser event order. We will send finalized `result` event as early as possible. This will not break conformance to W3C specifications. By [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/compulim/web-speech-cognitive-services/pull/XXX)
+
 ## [5.0.1] - 2019-10-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Speech recognition: New `strictEvents` option, default is `true`. When disabled, we will no longer follow observed browser event order. We will send finalized `result` event as early as possible. This will not break conformance to W3C specifications. By [@compulim](https://github.com/compulim), in PR [#79](https://github.com/compulim/web-speech-cognitive-services/pull/79)
+- Speech recognition: New `loosenEvents` option, default is `false`. When enabled, we will no longer follow observed browser event order. We will send finalized `result` event as early as possible. This will not break conformance to W3C specifications. By [@compulim](https://github.com/compulim), in PR [#79](https://github.com/compulim/web-speech-cognitive-services/pull/79)
 
 ## [5.0.1] - 2019-10-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Speech recognition: Removed extraneous finalized `result` event in continuous mode, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/compulim/web-speech-cognitive-services/pull/XXX)
+- Speech recognition: Removed extraneous finalized `result` event in continuous mode, by [@compulim](https://github.com/compulim), in PR [#79](https://github.com/compulim/web-speech-cognitive-services/pull/79)
 
 ### Added
 
-- Speech recognition: New `strictEvents` option, default is `true`. When disabled, we will no longer follow observed browser event order. We will send finalized `result` event as early as possible. This will not break conformance to W3C specifications. By [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/compulim/web-speech-cognitive-services/pull/XXX)
+- Speech recognition: New `strictEvents` option, default is `true`. When disabled, we will no longer follow observed browser event order. We will send finalized `result` event as early as possible. This will not break conformance to W3C specifications. By [@compulim](https://github.com/compulim), in PR [#79](https://github.com/compulim/web-speech-cognitive-services/pull/79)
 
 ## [5.0.1] - 2019-10-25
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,18 @@ The following list all options supported by the adapter.
     <tr>
       <td><code>enableTelemetry</code></td>
       <td><code>undefined</code></td>
-      <td>Pass-through option to enable or disable telemetry for Speech SDK recognizer as <a href="https://github.com/Microsoft/cognitive-services-speech-sdk-js#data--telemetry">outlined in Speech SDK</a>. This adapter does not collect any telemetry.<br /><br />By default, Speech SDK will collect telemetry unless this is set to <code>false</code>.</td>
+      <td>
+        Pass-through option to enable or disable telemetry for Speech SDK recognizer as <a href="https://github.com/Microsoft/cognitive-services-speech-sdk-js#data--telemetry">outlined in Speech SDK</a>. This adapter does not collect any telemetry.<br /><br />By default, Speech SDK will collect telemetry unless this is set to <code>false</code>.
+      </td>
+    </tr>
+    <tr>
+      <td><code>looseEvents: boolean</code></td>
+      <td><code>"false"</code></td>
+      <td>
+        Specifies if the event order should strictly follow observed browser behavior (<code>"false"</code>), or loosened behavior (<code>"true"</code>). Regardless of the option, the package will continue to <a href="https://wicg.github.io/speech-api/#eventdef-speechrecognition-result">conform with W3C specifications</a>.
+        <br /><br />
+        You can read more about this option in <a href="#event-order">event order section</a>.
+      </td>
     </tr>
     <tr>
       <td><code>ponyfill.AudioContext:&nbsp;<a href="https://developer.mozilla.org/en-US/docs/Web/API/AudioContext">AudioContext</a></code></td>
@@ -144,7 +155,9 @@ The following list all options supported by the adapter.
     <tr>
       <td><code>referenceGrammars:&nbsp;string[]</code></td>
       <td><code>undefined</code></td>
-      <td>Reference grammar IDs to send for speech recognition.</td>
+      <td>
+        Reference grammar IDs to send for speech recognition.
+      </td>
     </tr>
     <tr>
       <td><code>region:&nbsp;string</code></td>
@@ -171,11 +184,6 @@ The following list all options supported by the adapter.
       <td><code>speechSynthesisOutputFormat:&nbsp;string</code></td>
       <td><code>"audio-24khz-160kbitrate-mono-mp3"</code></td>
       <td>Audio format for speech synthesis. Please refer to <a href="https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/rest-text-to-speech#audio-outputs">this article</a> for list of supported formats.</td>
-    </tr>
-    <tr>
-      <td><code>strictEvents: boolean</code></td>
-      <td><code>"true"</code></td>
-      <td>Specifies if the event order should strictly follow observed behavior from browsers (<code>"true"</code>), or loosened behavior that still <a href="https://wicg.github.io/speech-api/#eventdef-speechrecognition-result">conforms to W3C spec</a> (<code>"false"</code>).
     </tr>
     <tr>
       <td><code>subscriptionKey:&nbsp;string</code></td>
@@ -430,13 +438,13 @@ utterance.voice = { voiceURI: 'your-model-name' };
 await speechSynthesis.speak(utterance);
 ```
 
-## Strict event orders
+## Event order
 
 According to [W3C specifications](https://wicg.github.io/speech-api/#eventdef-speechrecognition-result), the `result` event can be fire at any time after `audiostart` event.
 
 In continuous mode, finalized `result` event will be sent as early as possible. But in non-continuous mode, we observed browsers send finalized `result` event just before `audioend`, instead of as early as possible.
 
-By default, we follow strict event order observed from browsers. That means, for a speech recognition in non-continuous mode and with interims, the observed event order is:
+By default, we follow event order observed from browsers (a.k.a. strict event order). For a speech recognition in non-continuous mode and with interims, the observed event order will be:
 
 1. `start`
 1. `audiostart`
@@ -449,7 +457,7 @@ By default, we follow strict event order observed from browsers. That means, for
 1. `result` (with `isFinal` property set to `true`)
 1. `end`
 
-You can disable strict event orders by setting `strictEvents` to `false`. For the same scenario, the event order will become:
+You can loosen event order by setting `looseEvents` to `false`. For the same scenario, the event order will become:
 
 1. `start`
 1. `audiostart`
@@ -464,7 +472,7 @@ You can disable strict event orders by setting `strictEvents` to `false`. For th
 
 For `error` events (abort, `"no-speech"` or other errors), we always sent it just before the last `end` event.
 
-In some cases, disabling strict event orders may improve recognition performance. This will not break conformance to W3C standard.
+In some cases, loosening event order may improve recognition performance. This will not break conformance to W3C standard.
 
 # Test matrix
 

--- a/packages/component/package-lock.json
+++ b/packages/component/package-lock.json
@@ -7002,6 +7002,12 @@
 			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
 			"dev": true
 		},
+		"prettier": {
+			"version": "1.19.1",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+			"integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+			"dev": true
+		},
 		"pretty-format": {
 			"version": "24.8.0",
 			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.8.0.tgz",

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -65,6 +65,7 @@
     "eslint": "^6.1.0",
     "jest": "^24.8.0",
     "microsoft-speech-browser-sdk": "^0.0.12",
+    "prettier": "^1.19.1",
     "rimraf": "^2.6.3"
   },
   "dependencies": {

--- a/packages/component/src/SpeechServices/SpeechToText/__snapshots__/createSpeechRecognitionPonyfill.test.js.snap
+++ b/packages/component/src/SpeechServices/SpeechToText/__snapshots__/createSpeechRecognitionPonyfill.test.js.snap
@@ -59,7 +59,6 @@ Array [
   "webspeech:speechend",
   "webspeech:soundend",
   "webspeech:audioend",
-  "webspeech:result ['Hello.' (isFinal), 'World.' (isFinal)]",
   "webspeech:end",
 ]
 `;

--- a/packages/component/src/SpeechServices/SpeechToText/createSpeechRecognitionPonyfill.js
+++ b/packages/component/src/SpeechServices/SpeechToText/createSpeechRecognitionPonyfill.js
@@ -96,11 +96,12 @@ export default ({
   // https://github.com/Microsoft/cognitive-services-speech-sdk-js#data--telemetry
   enableTelemetry = true,
 
+  looseEvent,
+  looseEvents,
   referenceGrammars,
   region = 'westus',
   speechRecognitionEndpointId,
   subscriptionKey,
-  strictEvents = true,
   textNormalization = 'display'
 } = {}) => {
   if (!authorizationToken && !subscriptionKey) {
@@ -111,6 +112,12 @@ export default ({
     console.warn('web-speech-cognitive-services: This browser does not support WebRTC and it will not work with Cognitive Services Speech Services.');
 
     return {};
+  }
+
+  if (typeof looseEvent !== 'undefined') {
+    console.warn('web-speech-cognitive-services: The option "looseEvent" should be named as "looseEvents".');
+
+    looseEvents = looseEvent;
   }
 
   let onAudibleChunk;
@@ -447,9 +454,9 @@ export default ({
               recognizer.stopContinuousRecognitionAsync();
             }
 
-            // If strict event order is not required, we can send the recognized event as soon as we receive it.
-            // 1. If it is not recognizable (no-speech), we should send an "error" event, which means we cannot send sooner.
-            if (!strictEvents && finalEvent && recognizable) {
+            // If event order can be loosened, we can send the recognized event as soon as we receive it.
+            // 1. If it is not recognizable (no-speech), we should send an "error" event just before "end" event. We will not loosen "error" events.
+            if (looseEvents && finalEvent && recognizable) {
               this.dispatchEvent(new SpeechRecognitionEvent(finalEvent.type, finalEvent));
               finalEvent = null;
             }

--- a/packages/component/src/SpeechServices/SpeechToText/createSpeechRecognitionPonyfill.test.js
+++ b/packages/component/src/SpeechServices/SpeechToText/createSpeechRecognitionPonyfill.test.js
@@ -21,12 +21,13 @@ const MOCK_SPEECH_SDK = {
       const eventHandlers = [];
       const readResolves = [];
 
-      return ({
-        attach: () => PromiseHelper.fromResult({
-          read: () => ({
-            onSuccessContinueWith: resolve => readResolves.push(resolve)
-          })
-        }),
+      return {
+        attach: () =>
+          PromiseHelper.fromResult({
+            read: () => ({
+              onSuccessContinueWith: resolve => readResolves.push(resolve)
+            })
+          }),
         emitEvent: name => {
           eventHandlers.forEach(handler => handler({ name }));
         },
@@ -44,7 +45,7 @@ const MOCK_SPEECH_SDK = {
             };
           }
         }
-      });
+      };
     }
   },
   OutputFormat: {
@@ -134,13 +135,15 @@ function createRecognizedEvent(text, { confidence = 0.9, duration = 1, itn, lexi
       json: JSON.stringify({
         Duration: duration,
         Offset: offset,
-        NBest: [{
-          Confidence: confidence,
-          Lexical: lexical || text.toLowerCase(),
-          ITN: itn || text.toLowerCase(),
-          MaskedITN: maskedITN || text.toLowerCase(),
-          Display: text
-        }]
+        NBest: [
+          {
+            Confidence: confidence,
+            Lexical: lexical || text.toLowerCase(),
+            ITN: itn || text.toLowerCase(),
+            MaskedITN: maskedITN || text.toLowerCase(),
+            Display: text
+          }
+        ]
       }),
       offset: offset,
       reason: 3,
@@ -179,19 +182,25 @@ function toSnapshot(events) {
     const { type } = event;
 
     if (type === 'cognitiveservices') {
-      const { data: { type: subType } } = event;
+      const {
+        data: { type: subType }
+      } = event;
 
-      return `${ type }:${ subType }`;
+      return `${type}:${subType}`;
     } else {
       switch (type) {
         case 'error':
-          return `webspeech:error { error: '${ event.error }' }`;
+          return `webspeech:error { error: '${event.error}' }`;
 
         case 'result':
-          return `webspeech:result [${ event.results.map(results => [].map.call(results, ({ transcript }) => `'${ transcript }'${ results.isFinal ? ' (isFinal)' : '' }`)).join(', ') }]`;
+          return `webspeech:result [${event.results
+            .map(results =>
+              [].map.call(results, ({ transcript }) => `'${transcript}'${results.isFinal ? ' (isFinal)' : ''}`)
+            )
+            .join(', ')}]`;
 
         default:
-          return `webspeech:${ type }`;
+          return `webspeech:${type}`;
       }
     }
   });
@@ -201,7 +210,7 @@ let recognizer;
 
 beforeEach(() => {
   jest.resetModules();
-  jest.setMock('../SpeechSDK', ({
+  jest.setMock('../SpeechSDK', {
     ...MOCK_SPEECH_SDK,
     SpeechRecognizer: class extends MOCK_SPEECH_SDK.SpeechRecognizer {
       constructor(...args) {
@@ -209,13 +218,13 @@ beforeEach(() => {
         recognizer = this;
       }
     }
-  }));
+  });
 
   global.ErrorEvent = class {
     constructor(type, extras = {}) {
       this.type = type;
 
-      Object.keys(extras).forEach(name => this[name] = extras[name]);
+      Object.keys(extras).forEach(name => (this[name] = extras[name]));
     }
   };
 
@@ -920,13 +929,10 @@ describe('SpeechRecognition', () => {
     // webspeech:start
     // webspeech:audiostart
 
-    recognizer.canceled(
-      this,
-      {
-        errorDetails: 'Unable to contact server. StatusCode: 1006, Reason: ',
-        reason: 0
-      }
-    );
+    recognizer.canceled(this, {
+      errorDetails: 'Unable to contact server. StatusCode: 1006, Reason: ',
+      reason: 0
+    });
 
     // cognitiveservices:canceled
     // audioend
@@ -943,13 +949,10 @@ describe('SpeechRecognition', () => {
 
     await recognizer.waitForStartContinuousRecognitionAsync();
 
-    recognizer.canceled(
-      this,
-      {
-        errorDetails: 'Error occurred during microphone initialization: NotAllowedError: Permission denied',
-        reason: 0
-      }
-    );
+    recognizer.canceled(this, {
+      errorDetails: 'Error occurred during microphone initialization: NotAllowedError: Permission denied',
+      reason: 0
+    });
 
     // cognitiveservices:canceled
     // webspeech:error { error: 'not-allowed' }
@@ -994,7 +997,9 @@ describe('SpeechRecognition', () => {
     await recognizer.waitForStartContinuousRecognitionAsync();
 
     expect(recognizer.privReco.dynamicGrammar.addReferenceGrammar).toHaveBeenCalledTimes(1);
-    expect(recognizer.privReco.dynamicGrammar.addReferenceGrammar).toHaveBeenCalledWith(['12345678-1234-5678-abcd-12345678abcd']);
+    expect(recognizer.privReco.dynamicGrammar.addReferenceGrammar).toHaveBeenCalledWith([
+      '12345678-1234-5678-abcd-12345678abcd'
+    ]);
   });
 
   test('with new SpeechGrammarList', async () => {
@@ -1020,13 +1025,15 @@ describe('SpeechRecognition with text normalization', () => {
       RecognitionStatus: 'Success',
       Offset: 1800000,
       Duration: 48100000,
-      NBest: [{
-        Confidence: 0.2331869,
-        Lexical: 'no (Lexical)',
-        ITN: 'no (ITN)',
-        MaskedITN: 'no (MaskedITN)',
-        Display: 'No.'
-      }]
+      NBest: [
+        {
+          Confidence: 0.2331869,
+          Lexical: 'no (Lexical)',
+          ITN: 'no (ITN)',
+          MaskedITN: 'no (MaskedITN)',
+          Display: 'No.'
+        }
+      ]
     }),
     offset: 1800000,
     reason: 3
@@ -1231,5 +1238,465 @@ describe('SpeechRecognition with telemetry', () => {
 
     expect(MOCK_SPEECH_SDK.SpeechRecognizer.enableTelemetry).toHaveBeenCalledTimes(1);
     expect(MOCK_SPEECH_SDK.SpeechRecognizer.enableTelemetry).toHaveBeenCalledWith(true);
+  });
+});
+
+describe('SpeechRecognition without strict events', () => {
+  let endEventEmitted;
+  let errorEventEmitted;
+  let events;
+  let speechRecognition;
+
+  beforeEach(async () => {
+    const { default: createSpeechRecognitionPonyfill } = require('./createSpeechRecognitionPonyfill');
+    const { SpeechRecognition } = createSpeechRecognitionPonyfill({
+      region: 'westus',
+      subscriptionKey: 'SUBSCRIPTION_KEY',
+      strictEvents: false
+    });
+
+    speechRecognition = new SpeechRecognition();
+    events = captureSpeechEvents(speechRecognition);
+    endEventEmitted = new Promise(resolve => speechRecognition.addEventListener('end', resolve));
+    errorEventEmitted = new Promise(resolve => speechRecognition.addEventListener('error', resolve));
+  });
+
+  describe('in interactive mode', () => {
+    test('without interims', async () => {
+      speechRecognition.start();
+      await recognizer.waitForStartContinuousRecognitionAsync();
+
+      // This will fire "firstAudibleChunk" on "emitRead"
+      recognizer.readAudioChunk();
+
+      recognizer.audioConfig.emitEvent('AudioSourceReadyEvent');
+
+      // cognitiveservices:audioSourceReady
+      // webspeech:start
+      // webspeech:audiostart
+
+      recognizer.audioConfig.emitRead();
+
+      // cognitiveservices:firstAudibleChunk
+      // webspeech:soundstart
+
+      recognizer.recognizing(this, createRecognizingEvent('hello world'));
+
+      // cognitiveservices:recognizing
+      // webspeech:speechstart
+
+      recognizer.recognized(this, createRecognizedEvent('Hello, World!'));
+
+      // cognitiveservices:recognized
+      // webspeech:result ["Hello, World!" (isFinal)]
+
+      recognizer.audioConfig.emitEvent('AudioSourceOffEvent');
+
+      // cognitiveservices:audioSourceOff
+      // webspeech:speechend
+      // webspeech:soundend
+      // webspeech:audioend
+      // webspeech:end
+
+      await endEventEmitted;
+
+      expect(toSnapshot(events)).toMatchInlineSnapshot(`
+        Array [
+          "cognitiveservices:audioSourceReady",
+          "webspeech:start",
+          "webspeech:audiostart",
+          "cognitiveservices:firstAudibleChunk",
+          "webspeech:soundstart",
+          "cognitiveservices:recognizing",
+          "webspeech:speechstart",
+          "cognitiveservices:recognized",
+          "webspeech:result ['Hello, World!' (isFinal)]",
+          "cognitiveservices:audioSourceOff",
+          "webspeech:speechend",
+          "webspeech:soundend",
+          "webspeech:audioend",
+          "webspeech:end",
+        ]
+      `);
+    });
+
+    test('with interims', async () => {
+      speechRecognition.interimResults = true;
+      speechRecognition.start();
+      await recognizer.waitForStartContinuousRecognitionAsync();
+
+      // This will fire "firstAudibleChunk" on "emitRead"
+      recognizer.readAudioChunk();
+
+      recognizer.audioConfig.emitEvent('AudioSourceReadyEvent');
+
+      // cognitiveservices:audioSourceReady
+      // webspeech:start
+      // webspeech:audiostart
+
+      recognizer.audioConfig.emitRead();
+
+      // cognitiveservices:firstAudibleChunk
+      // webspeech:soundstart
+
+      recognizer.recognizing(this, createRecognizingEvent('hello'));
+
+      // cognitiveservices:recognizing
+      // webspeech:speechstart
+      // webspeech:result ["hello"]
+
+      recognizer.recognizing(this, createRecognizingEvent('hello world'));
+
+      // cognitiveservices:recognizing
+      // webspeech:result ["hello world"]
+
+      recognizer.recognized(this, createRecognizedEvent('Hello, World!'));
+
+      // cognitiveservices:recognized
+      // webspeech:result ["Hello, World!" (isFinal)]
+
+      recognizer.audioConfig.emitEvent('AudioSourceOffEvent');
+
+      // cognitiveservices:audioSourceOff
+      // webspeech:speechend
+      // webspeech:soundend
+      // webspeech:audioend
+      // webspeech:end
+
+      await endEventEmitted;
+
+      expect(toSnapshot(events)).toMatchInlineSnapshot(`
+        Array [
+          "cognitiveservices:audioSourceReady",
+          "webspeech:start",
+          "webspeech:audiostart",
+          "cognitiveservices:firstAudibleChunk",
+          "webspeech:soundstart",
+          "cognitiveservices:recognizing",
+          "webspeech:speechstart",
+          "webspeech:result ['hello']",
+          "cognitiveservices:recognizing",
+          "webspeech:result ['hello world']",
+          "cognitiveservices:recognized",
+          "webspeech:result ['Hello, World!' (isFinal)]",
+          "cognitiveservices:audioSourceOff",
+          "webspeech:speechend",
+          "webspeech:soundend",
+          "webspeech:audioend",
+          "webspeech:end",
+        ]
+      `);
+    });
+
+    test('with muted microphone', async () => {
+      speechRecognition.start();
+      await recognizer.waitForStartContinuousRecognitionAsync();
+
+      // This will fire "firstAudibleChunk" on "emitRead"
+      recognizer.readAudioChunk();
+
+      recognizer.audioConfig.emitEvent('AudioSourceReadyEvent');
+
+      // cognitiveservices:audioSourceReady
+      // webspeech:start
+      // webspeech:audiostart
+
+      recognizer.audioConfig.emitRead([0x00, 0x00]);
+
+      recognizer.recognized(this, {
+        offset: 50000000,
+        result: {
+          duration: 0,
+          json: JSON.stringify({
+            RecognitionStatus: 'InitialSilenceTimeout',
+            Offset: 50000000,
+            Duration: 0
+          }),
+          offset: 50000000,
+          reason: 0
+        }
+      });
+
+      // cognitiveservices:recognized
+
+      recognizer.audioConfig.emitEvent('AudioSourceOffEvent');
+
+      // cognitiveservices:audioSourceOff
+      // webspeech:audioend
+      // webspeech:error { error: 'no-speech' }
+      // webspeech:end
+
+      await errorEventEmitted;
+
+      expect(toSnapshot(events)).toMatchInlineSnapshot(`
+        Array [
+          "cognitiveservices:audioSourceReady",
+          "webspeech:start",
+          "webspeech:audiostart",
+          "cognitiveservices:recognized",
+          "cognitiveservices:audioSourceOff",
+          "webspeech:audioend",
+          "webspeech:error { error: 'no-speech' }",
+          "webspeech:end",
+        ]
+      `);
+    });
+
+    test('with unrecognizable sound should throw error', async () => {
+      speechRecognition.start();
+      await recognizer.waitForStartContinuousRecognitionAsync();
+
+      // This will fire "firstAudibleChunk" on "emitRead"
+      recognizer.readAudioChunk();
+
+      recognizer.audioConfig.emitEvent('AudioSourceReadyEvent');
+
+      // cognitiveservices:audioSourceReady
+      // webspeech:start
+      // webspeech:audiostart
+
+      recognizer.audioConfig.emitRead();
+
+      // cognitiveservices:firstAudibleChunk
+      // webspeech:soundstart
+
+      recognizer.recognized(this, createRecognizedEvent(''));
+
+      // cognitiveservices:recognized
+      // webspeech:speechstart
+
+      speechRecognition.stop();
+
+      // cognitiveservices:stop
+
+      recognizer.audioConfig.emitEvent('AudioSourceOffEvent');
+
+      // cognitiveservices:audioSourceOff
+      // webspeech:speechend
+      // webspeech:soundend
+      // webspeech:audioend
+      // webspeech:error { error: 'no-speech' }
+      // webspeech:end
+
+      await endEventEmitted;
+
+      expect(toSnapshot(events)).toMatchInlineSnapshot(`
+        Array [
+          "cognitiveservices:audioSourceReady",
+          "webspeech:start",
+          "webspeech:audiostart",
+          "cognitiveservices:firstAudibleChunk",
+          "webspeech:soundstart",
+          "cognitiveservices:recognized",
+          "webspeech:speechstart",
+          "cognitiveservices:stop",
+          "cognitiveservices:audioSourceOff",
+          "webspeech:speechend",
+          "webspeech:soundend",
+          "webspeech:audioend",
+          "webspeech:error { error: 'no-speech' }",
+          "webspeech:end",
+        ]
+      `);
+    });
+  });
+
+  describe('in continuous mode', () => {
+    test('with unrecognizable sound should throw error', async () => {
+      speechRecognition.start();
+      speechRecognition.continuous = true;
+      speechRecognition.interimResults = true;
+      await recognizer.waitForStartContinuousRecognitionAsync();
+
+      // This will fire "firstAudibleChunk" on "emitRead"
+      recognizer.readAudioChunk();
+
+      recognizer.audioConfig.emitEvent('AudioSourceReadyEvent');
+
+      // cognitiveservices:audioSourceReady
+      // webspeech:start
+      // webspeech:audiostart
+
+      recognizer.audioConfig.emitRead();
+
+      // cognitiveservices:firstAudibleChunk
+      // webspeech:soundstart
+
+      recognizer.recognized(this, createRecognizedEvent(''));
+
+      // cognitiveservices:recognized
+      // webspeech:speechstart
+
+      speechRecognition.stop();
+
+      // cognitiveservices:stop
+
+      recognizer.audioConfig.emitEvent('AudioSourceOffEvent');
+
+      // cognitiveservices:audioSourceOff
+      // webspeech:speechend
+      // webspeech:soundend
+      // webspeech:audioend
+      // webspeech:error { error: 'no-speech' }
+      // webspeech:end
+
+      await endEventEmitted;
+
+      expect(toSnapshot(events)).toMatchInlineSnapshot(`
+        Array [
+          "cognitiveservices:audioSourceReady",
+          "webspeech:start",
+          "webspeech:audiostart",
+          "cognitiveservices:firstAudibleChunk",
+          "webspeech:soundstart",
+          "cognitiveservices:recognized",
+          "webspeech:speechstart",
+          "cognitiveservices:stop",
+          "cognitiveservices:audioSourceOff",
+          "webspeech:speechend",
+          "webspeech:soundend",
+          "webspeech:audioend",
+          "webspeech:error { error: 'no-speech' }",
+          "webspeech:end",
+        ]
+      `);
+    });
+
+    test('stop after recognized 1 speech and 1 ongoing', async () => {
+      speechRecognition.start();
+      speechRecognition.continuous = true;
+      speechRecognition.interimResults = true;
+      await recognizer.waitForStartContinuousRecognitionAsync();
+
+      // This will fire "firstAudibleChunk" on "emitRead"
+      recognizer.readAudioChunk();
+
+      recognizer.audioConfig.emitEvent('AudioSourceReadyEvent');
+
+      // cognitiveservices:audioSourceReady
+      // webspeech:start
+      // webspeech:audiostart
+
+      recognizer.audioConfig.emitRead();
+
+      // cognitiveservices:firstAudibleChunk
+      // webspeech:soundstart
+
+      recognizer.recognizing(this, createRecognizingEvent('hello'));
+
+      // cognitiveservices:recognizing
+      // webspeech:speechstart
+      // webspeech:result ['hello']
+
+      recognizer.recognized(this, createRecognizedEvent('Hello.'));
+
+      // cognitiveservices:recognized
+      // webspeech:result ['Hello.' (isFinal)]
+
+      speechRecognition.stop();
+
+      // cognitiveservices:stop
+
+      recognizer.recognized(this, createRecognizedEvent('World.'));
+
+      // cognitiveservices:recognized
+      // webspeech:result ['Hello.' (isFinal), 'World.' (isFinal)]
+
+      recognizer.audioConfig.emitEvent('AudioSourceOffEvent');
+
+      // cognitiveservices:audioSourceOff
+      // webspeech:speechend
+      // webspeech:soundend
+      // webspeech:audioend
+      // webspeech:result ['Hello.' (isFinal), 'World.' (isFinal)]
+      // webspeech:end
+
+      await endEventEmitted;
+
+      expect(toSnapshot(events)).toMatchInlineSnapshot(`
+        Array [
+          "cognitiveservices:audioSourceReady",
+          "webspeech:start",
+          "webspeech:audiostart",
+          "cognitiveservices:firstAudibleChunk",
+          "webspeech:soundstart",
+          "cognitiveservices:recognizing",
+          "webspeech:speechstart",
+          "webspeech:result ['hello']",
+          "cognitiveservices:recognized",
+          "webspeech:result ['Hello.' (isFinal)]",
+          "cognitiveservices:stop",
+          "cognitiveservices:recognized",
+          "webspeech:result ['Hello.' (isFinal), 'World.' (isFinal)]",
+          "cognitiveservices:audioSourceOff",
+          "webspeech:speechend",
+          "webspeech:soundend",
+          "webspeech:audioend",
+          "webspeech:end",
+        ]
+      `);
+    });
+
+    test('abort after recognized', async () => {
+      speechRecognition.start();
+      speechRecognition.continuous = true;
+      speechRecognition.interimResults = true;
+      await recognizer.waitForStartContinuousRecognitionAsync();
+
+      // This will fire "firstAudibleChunk" on "emitRead"
+      recognizer.readAudioChunk();
+
+      recognizer.audioConfig.emitEvent('AudioSourceReadyEvent');
+
+      // cognitiveservices:audioSourceReady
+      // webspeech:start
+      // webspeech:audiostart
+
+      recognizer.audioConfig.emitRead();
+
+      // cognitiveservices:firstAudibleChunk
+      // webspeech:soundstart
+
+      recognizer.recognized(this, createRecognizedEvent('Hello, World!'));
+
+      // cognitiveservices:recognized
+      // webspeech:speechstart
+      // webspeech:result ['Hello, World!' (isFinal)]
+
+      speechRecognition.abort();
+
+      // cognitiveservices:abort
+
+      recognizer.audioConfig.emitEvent('AudioSourceOffEvent');
+
+      // cognitiveservices:audioSourceOff
+      // webspeech:speechend
+      // webspeech:soundend
+      // webspeech:audioend
+      // webspeech:error { error: 'aborted' }
+      // webspeech:end
+
+      await endEventEmitted;
+
+      expect(toSnapshot(events)).toMatchInlineSnapshot(`
+        Array [
+          "cognitiveservices:audioSourceReady",
+          "webspeech:start",
+          "webspeech:audiostart",
+          "cognitiveservices:firstAudibleChunk",
+          "webspeech:soundstart",
+          "cognitiveservices:recognized",
+          "webspeech:speechstart",
+          "webspeech:result ['Hello, World!' (isFinal)]",
+          "cognitiveservices:abort",
+          "cognitiveservices:audioSourceOff",
+          "webspeech:speechend",
+          "webspeech:soundend",
+          "webspeech:audioend",
+          "webspeech:error { error: 'aborted' }",
+          "webspeech:end",
+        ]
+      `);
+    });
   });
 });

--- a/packages/component/src/SpeechServices/SpeechToText/createSpeechRecognitionPonyfill.test.js
+++ b/packages/component/src/SpeechServices/SpeechToText/createSpeechRecognitionPonyfill.test.js
@@ -1241,7 +1241,7 @@ describe('SpeechRecognition with telemetry', () => {
   });
 });
 
-describe('SpeechRecognition without strict events', () => {
+describe('SpeechRecognition with loosened events', () => {
   let endEventEmitted;
   let errorEventEmitted;
   let events;
@@ -1252,7 +1252,7 @@ describe('SpeechRecognition without strict events', () => {
     const { SpeechRecognition } = createSpeechRecognitionPonyfill({
       region: 'westus',
       subscriptionKey: 'SUBSCRIPTION_KEY',
-      strictEvents: false
+      looseEvents: true
     });
 
     speechRecognition = new SpeechRecognition();


### PR DESCRIPTION
## Description

A new option to optionally loosen the event order to improve latency on speech recognition.

## README

### Strict event orders

According to [W3C specifications](https://wicg.github.io/speech-api/#eventdef-speechrecognition-result), the `result` event can be fire at any time after `audiostart` event.

In continuous mode, finalized `result` event will be sent as early as possible. But in non-continuous mode, we observed browsers send finalized `result` event just before `audioend`, instead of as early as possible.

By default, we follow strict event order observed from browsers. That means, for a speech recognition in non-continuous mode and with interims, the observed event order is:

1. `start`
1. `audiostart`
1. `soundstart`
1. `speechstart`
1. `result` (these are interim results, with `isFinal` property set to `false`)
1. `speechend`
1. `soundend`
1. `audioend`
1. `result` (with `isFinal` property set to `true`)
1. `end`

You can disable strict event orders by setting `strictEvents` to `false`. For the same scenario, the event order will become:

1. `start`
1. `audiostart`
1. `soundstart`
1. `speechstart`
1. `result` (these are interim results, with `isFinal` property set to `false`)
1. `result` (with `isFinal` property set to `true`)
1. `speechend`
1. `soundend`
1. `audioend`
1. `end`

For `error` events (abort, `"no-speech"` or other errors), we always sent it just before the last `end` event.

In some cases, disabling strict event orders may improve recognition performance. This will not break conformance to W3C standard.

## Changelog

### Fixed

- Speech recognition: Removed extraneous finalized `result` event in continuous mode, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/compulim/web-speech-cognitive-services/pull/XXX)

### Added

- Speech recognition: New `strictEvents` option, default is `true`. When disabled, we will no longer follow observed browser event order. We will send finalized `result` event as early as possible. This will not break conformance to W3C specifications. By [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/compulim/web-speech-cognitive-services/pull/XXX)