### PR TITLE
Unify credentials options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,39 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Breaking changes
+
+#### Unifying options to pass credentials
+
+`authorizationToken`, `region`, and `subscriptionKey` are being deprecated in favor of `credentials` options. `credentials` can be one of the following types:
+
+- `{ authorizationToken: string, region: string }`
+- `{ region: string, subscriptionKey: string }`
+- `Promise<{ authorizationToken: string, region: string }>`
+- `Promise<{ region: string, subscriptionKey: string }>`
+- `() => { authorizationToken: string, region: string }`
+- `() => { region: string, subscriptionKey: string }`
+- `() => Promise<{ authorizationToken: string, region: string }>`
+- `() => Promise<{ region: string, subscriptionKey: string }>`
+
+If `credentials` is a function, it will be called just before the credentials is needed and may be called very frequently. This behavior matches the deprecating `authorizationToken`. The result of the call is also expected to be cached.
+
+If `region` is not returned, the default value of `"westus"` will be used.
+
 ### Fixed
 
 - Speech recognition: Removed extraneous finalized `result` event in continuous mode, by [@compulim](https://github.com/compulim), in PR [#79](https://github.com/compulim/web-speech-cognitive-services/pull/79)
+
+### Removed
+
+- `authorizationToken`, `region`, and `subscriptionKey` are being deprecated in favor of `credentials` options.
 
 ### Added
 
 - `playground`: Add delayed start to playground for testing speech recognition initiated outside of user gestures, in PR [#78](https://github.com/compulim/web-speech-congitive-services/pull/78)
 - Speech recognition: New `looseEvents` option, default is `false`. When enabled, we will no longer follow observed browser event order. We will send finalized `result` event as early as possible. This will not break conformance to W3C specifications. By [@compulim](https://github.com/compulim), in PR [#79](https://github.com/compulim/web-speech-cognitive-services/pull/79)
 - Speech recognition: Create ponyfill using `SpeechRecognizer` object from [`microsoft-cognitiveservices-speech-sdk`](https://npmjs.com/package/microsoft-cognitiveservices-speech-sdk), by [@compulim](https://github.com/compulim), in PR [#73](https://github.com/compulim/web-speech-cognitive-services/pull/73)
+- `credentials` option is added for obtaining authorization token and region, or subscription key and region, in a single object or function call, in PR [#XXX](https://github.com/compulim/web-speech-cognitive-services/pull/XXX)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 `authorizationToken`, `region`, and `subscriptionKey` are being deprecated in favor of `credentials` options. `credentials` can be one of the following types:
 
-- `{ authorizationToken: string, region: string }`
-- `{ region: string, subscriptionKey: string }`
-- `Promise<{ authorizationToken: string, region: string }>`
-- `Promise<{ region: string, subscriptionKey: string }>`
-- `() => { authorizationToken: string, region: string }`
-- `() => { region: string, subscriptionKey: string }`
-- `() => Promise<{ authorizationToken: string, region: string }>`
-- `() => Promise<{ region: string, subscriptionKey: string }>`
+- `{ authorizationToken: string, region: string? }`
+- `{ region: string?, subscriptionKey: string }`
+- `Promise<{ authorizationToken: string, region: string? }>`
+- `Promise<{ region: string?, subscriptionKey: string }>`
+- `() => { authorizationToken: string, region: string? }`
+- `() => { region: string?, subscriptionKey: string }`
+- `() => Promise<{ authorizationToken: string, region: string? }>`
+- `() => Promise<{ region: string?, subscriptionKey: string }>`
 
 If `credentials` is a function, it will be called just before the credentials is needed and may be called very frequently. This behavior matches the deprecating `authorizationToken`. The result of the call is also expected to be cached.
 
@@ -31,14 +31,14 @@ If `region` is not returned, the default value of `"westus"` will be used.
 
 ### Removed
 
-- `authorizationToken`, `region`, and `subscriptionKey` are being deprecated in favor of `credentials` options.
+- 🔥 `authorizationToken`, `region`, and `subscriptionKey` are being deprecated in favor of `credentials` options, by [@compulim](https://github.com/compulim) in PR [#80](https://github.com/compulim/web-speech-cognitive-services/pull/80)
 
 ### Added
 
 - `playground`: Add delayed start to playground for testing speech recognition initiated outside of user gestures, in PR [#78](https://github.com/compulim/web-speech-congitive-services/pull/78)
 - Speech recognition: New `looseEvents` option, default is `false`. When enabled, we will no longer follow observed browser event order. We will send finalized `result` event as early as possible. This will not break conformance to W3C specifications. By [@compulim](https://github.com/compulim), in PR [#79](https://github.com/compulim/web-speech-cognitive-services/pull/79)
 - Speech recognition: Create ponyfill using `SpeechRecognizer` object from [`microsoft-cognitiveservices-speech-sdk`](https://npmjs.com/package/microsoft-cognitiveservices-speech-sdk), by [@compulim](https://github.com/compulim), in PR [#73](https://github.com/compulim/web-speech-cognitive-services/pull/73)
-- `credentials` option is added for obtaining authorization token and region, or subscription key and region, in a single object or function call, in PR [#XXX](https://github.com/compulim/web-speech-cognitive-services/pull/XXX)
+- `credentials` option is added for obtaining authorization token and region, or subscription key and region, in a single object or function call, by [@compulim](https://github.com/compulim) in PR [#80](https://github.com/compulim/web-speech-cognitive-services/pull/80)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,10 @@ In the sample below, we use the bundle to perform text-to-speech with a voice na
   <body>
     <script>
       const { speechSynthesis, SpeechSynthesisUtterance } = window.WebSpeechCognitiveServices.create({
-        region: 'westus',
-        subscriptionKey: 'YOUR_SUBSCRIPTION_KEY'
+        credentials: {
+          region: 'westus',
+          subscriptionKey: 'YOUR_SUBSCRIPTION_KEY'
+        }
       });
 
       speechSynthesis.addEventListener('voiceschanged', () => {
@@ -116,16 +118,26 @@ The following list all options supported by the adapter.
     </tr>
     <tr>
       <td>
-        <code>authorizationToken:&nbsp;(</code><br />
-        <code>&nbsp;&nbsp;string&nbsp;||</code><br />
-        <code>&nbsp;&nbsp;Promise&lt;string&gt;&nbsp;||</code><br />
-        <code>&nbsp;&nbsp;()&nbsp;=>&nbsp;string&nbsp;||</code><br />
-        <code>&nbsp;&nbsp;()&nbsp;=>&nbsp;Promise&lt;string&gt;</code><br />
-        <code>)</code>
+        <code>credentials:&nbsp;(</code><br />
+        <code>&nbsp;&nbsp;Credentials&nbsp;||</code><br />
+        <code>&nbsp;&nbsp;Promise&lt;Credentials&gt;&nbsp;||</code><br />
+        <code>&nbsp;&nbsp;()&nbsp;=>&nbsp;Credentials&nbsp;||</code><br />
+        <code>&nbsp;&nbsp;()&nbsp;=>&nbsp;Promise&lt;Credentials&gt;</code><br />
+        <code>)</code><br />
+        <br />
+        <code>ICredentials: {</code><br />
+        <code>&nbsp;&nbsp;authorizationToken: string,</code><br />
+        <code>&nbsp;&nbsp;region: string</code><br />
+        <code>} || {</code><br />
+        <code>&nbsp;&nbsp;region: string,</code><br />
+        <code>&nbsp;&nbsp;subscriptionKey: string</code><br />
+        <code>}</code>
       </td>
-      <td>(Requires either<br /><code>authorizationToken</code> or<br /><code>subscriptionKey</code>)</td>
+      <td>(Required)</td>
       <td>
-        Authorization token from Cognitive Services. Please refer to <a href="https://docs.microsoft.com/en-us/azure/cognitive-services/authentication">this article</a> to obtain an authorization token.
+        Credentials (including Azure region) from Cognitive Services. Please refer to <a href="https://docs.microsoft.com/en-us/azure/cognitive-services/authentication">this article</a> to obtain an authorization token.<br />
+        <br />
+        Subscription key is not recommended for production use as it will be leaked in the browser.
       </td>
     </tr>
     <tr>
@@ -160,13 +172,6 @@ The following list all options supported by the adapter.
       </td>
     </tr>
     <tr>
-      <td><code>region:&nbsp;string</code></td>
-      <td><code>"westus"</code></td>
-      <td>
-        Azure region of Cognitive Services to use.
-      </td>
-    </tr>
-    <tr>
       <td><code>speechRecognitionEndpointId:&nbsp;string</code></td>
       <td><code>undefined</code></td>
       <td>
@@ -184,13 +189,6 @@ The following list all options supported by the adapter.
       <td><code>speechSynthesisOutputFormat:&nbsp;string</code></td>
       <td><code>"audio-24khz-160kbitrate-mono-mp3"</code></td>
       <td>Audio format for speech synthesis. Please refer to <a href="https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/rest-text-to-speech#audio-outputs">this article</a> for list of supported formats.</td>
-    </tr>
-    <tr>
-      <td><code>subscriptionKey:&nbsp;string</code></td>
-      <td>(Requires either<br /><code>authorizationToken</code> or<br /><code>subscriptionKey</code>)</td>
-      <td>
-        Subscription key to use. This is not recommended for production use as the subscription key will be leaked in the browser.
-      </td>
     </tr>
     <tr>
       <td><code>textNormalization:&nbsp;string</code></td>
@@ -220,8 +218,10 @@ import { createSpeechRecognitionPonyfill } from 'web-speech-cognitive-services/l
 const {
   SpeechRecognition
 } = await createSpeechRecognitionPonyfill({
-  region: 'westus',
-  subscriptionKey: 'YOUR_SUBSCRIPTION_KEY'
+  credentials: {
+    region: 'westus',
+    subscriptionKey: 'YOUR_SUBSCRIPTION_KEY'
+  }
 });
 
 const recognition = new SpeechRecognition();
@@ -250,8 +250,10 @@ const {
   SpeechGrammarList,
   SpeechRecognition
 } = await createPonyfill({
-  region: 'westus',
-  subscriptionKey: 'YOUR_SUBSCRIPTION_KEY'
+  credentials: {
+    region: 'westus',
+    subscriptionKey: 'YOUR_SUBSCRIPTION_KEY'
+  }
 });
 
 export default props =>
@@ -273,8 +275,10 @@ const {
   speechSynthesis,
   SpeechSynthesisUtterance
 } = await createSpeechSynthesisPonyfill({
-  region: 'westus',
-  subscriptionKey: 'YOUR_SUBSCRIPTION_KEY'
+  credentials: {
+    region: 'westus',
+    subscriptionKey: 'YOUR_SUBSCRIPTION_KEY'
+  }
 });
 
 speechSynthesis.addEventListener('voiceschanged', () => {
@@ -299,40 +303,30 @@ You can use [`react-say`](https://github.com/compulim/react-say/) to integrate s
 
 ```jsx
 import createPonyfill from 'web-speech-cognitive-services/lib/SpeechServices';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Say from 'react-say';
 
-export default class extends React.Component {
-  constructor(props) {
-    super(props);
+export default () => {
+  const [ponyfill, setPonyfill] = useState();
 
-    this.state = {};
-  }
+  useEffect(async () => {
+    setPonyfill(await createPonyfill({
+      credentials: {
+        region: 'westus',
+        subscriptionKey: 'YOUR_SUBSCRIPTION_KEY'
+      }
+    }));
+  }, [setPonyfill]);
 
-  async componentDidMount() {
-    const ponyfill = await createPonyfill({
-      region: 'westus',
-      subscriptionKey: 'YOUR_SUBSCRIPTION_KEY'
-    });
-
-    this.setState(() => ({ ponyfill }));
-  }
-
-  render() {
-    const {
-      state: { ponyfill }
-    } = this;
-
-    return (
-      ponyfill &&
-        <Say
-          speechSynthesis={ ponyfill.speechSynthesis }
-          speechSynthesisUtterance={ ponyfill.SpeechSynthesisUtterance }
-          text="Hello, World!"
-        />
-    );
-  }
-}
+  return (
+    ponyfill &&
+      <Say
+        speechSynthesis={ ponyfill.speechSynthesis }
+        speechSynthesisUtterance={ ponyfill.SpeechSynthesisUtterance }
+        text="Hello, World!"
+      />
+  );
+};
 ```
 
 ## Using authorization token
@@ -343,19 +337,23 @@ Instead of exposing subscription key on the browser, we strongly recommend using
 import createPonyfill from 'web-speech-cognitive-services/lib/SpeechServices';
 
 const ponyfill = await createPonyfill({
-  authorizationToken: 'YOUR_AUTHORIZATION_TOKEN',
-  region: 'westus',
+  credentials: {
+    authorizationToken: 'YOUR_AUTHORIZATION_TOKEN',
+    region: 'westus'
+  }
 });
 ```
 
-You can also provide an async function that will fetch the authorization token on-demand. You should cache the authorization token for subsequent request. For simplicity of this code snippets, we are not caching the result.
+You can also provide an async function that will fetch the authorization token and Azure region on-demand. You should cache the authorization token for subsequent request. For simplicity of this code snippets, we are not caching the result.
 
 ```jsx
 import createPonyfill from 'web-speech-cognitive-services/lib/SpeechServices';
 
 const ponyfill = await createPonyfill({
-  authorizationToken: () => fetch('https://example.com/your-token').then(res => res.text()),
-  region: 'westus',
+  credentials: () => fetch('https://example.com/your-token').then(res => ({
+    authorizationToken: res.text(),
+    region: 'westus'
+  }))
 });
 ```
 
@@ -382,8 +380,10 @@ const {
   SpeechGrammarList,
   SpeechRecognition
 } = await createPonyfill({
-  region: 'westus',
-  subscriptionKey: 'YOUR_SUBSCRIPTION_KEY'
+  credentials: {
+    region: 'westus',
+    subscriptionKey: 'YOUR_SUBSCRIPTION_KEY'
+  }
 });
 
 const recognition = new SpeechRecognition();
@@ -408,9 +408,11 @@ To use custom speech for speech recognition, you need to pass the endpoint ID wh
 import createPonyfill from 'web-speech-cognitive-services/lib/SpeechServices';
 
 const ponyfill = await createPonyfill({
-  region: 'westus',
+  credentials: {
+    region: 'westus',
+    subscriptionKey: 'YOUR_SUBSCRIPTION_KEY'
+  },
   speechRecognitionEndpointId: '12345678-1234-5678-abcd-12345678abcd',
-  subscriptionKey: 'YOUR_SUBSCRIPTION_KEY'
 });
 ```
 
@@ -424,9 +426,11 @@ To use Custom Voice for speech synthesis, you need to pass the deployment ID whi
 import createPonyfill from 'web-speech-cognitive-services/lib/SpeechServices';
 
 const ponyfill = await createPonyfill({
-  region: 'westus',
+  credentials: {
+    region: 'westus',
+    subscriptionKey: 'YOUR_SUBSCRIPTION_KEY'
+  },
   speechSynthesisDeploymentId: '12345678-1234-5678-abcd-12345678abcd',
-  subscriptionKey: 'YOUR_SUBSCRIPTION_KEY'
 });
 
 const { speechSynthesis, SpeechSynthesisUtterance } = ponyfill;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "clean": "lerna run --parallel --stream clean",
     "eslint": "lerna run --scope=bundle --scope=web-speech-cognitive-services --parallel --stream eslint",
     "prepublishOnly": "lerna run --stream prepublishOnly",
-    "start": "lerna run --parallel --stream start --scope=bundle --scope=web-speech-cognitive-services",
+    "start": "lerna run --parallel --stream start",
     "test": "lerna run --stream test"
   },
   "devDependencies": {

--- a/packages/component/package-lock.json
+++ b/packages/component/package-lock.json
@@ -5052,6 +5052,12 @@
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
 		},
+		"lolex": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.1.tgz",
+			"integrity": "sha512-dEwHz1CJ8DsdgfpiimgQQEhEJYOEiJ69a0s4aJDNHajaTqOJuF34vBAWVa/sS0V8aQvt72p+KgQ3pRmEVJM+iA==",
+			"dev": true
+		},
 		"loose-envify": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -62,6 +62,7 @@
     "babel-plugin-transform-inline-environment-variables": "^0.4.3",
     "eslint": "^6.6.0",
     "jest": "^24.9.0",
+    "lolex": "^5.1.1",
     "microsoft-speech-browser-sdk": "^0.0.12",
     "prettier": "^1.19.1",
     "rimraf": "^3.0.0"

--- a/packages/component/src/SpeechServices.js
+++ b/packages/component/src/SpeechServices.js
@@ -4,15 +4,7 @@ import createSpeechRecognitionPonyfill, { createSpeechRecognitionPonyfillFromRec
 import createSpeechSynthesisPonyfill from './SpeechServices/TextToSpeech';
 import fetchAuthorizationToken from './SpeechServices/fetchAuthorizationToken';
 
-let shouldWarnOnSubscriptionKey = true;
-
 export default function createSpeechServicesPonyfill(options = {}, ...args) {
-  if (shouldWarnOnSubscriptionKey && options.subscriptionKey) {
-    console.warn('web-speech-cognitive-services: In production environment, subscription key should not be used, authorization token should be used instead.');
-
-    shouldWarnOnSubscriptionKey = false;
-  }
-
   const ponyfill = {
     ...createSpeechRecognitionPonyfill(options, ...args),
     ...createSpeechSynthesisPonyfill(options, ...args),

--- a/packages/component/src/SpeechServices/TextToSpeech/SpeechSynthesisUtterance.js
+++ b/packages/component/src/SpeechServices/TextToSpeech/SpeechSynthesisUtterance.js
@@ -80,18 +80,16 @@ class SpeechSynthesisUtterance extends EventTarget {
 
   async preload({
     deploymentId,
-    getAuthorizationToken,
-    outputFormat,
-    region
+    fetchAuthorizationTokenCredentials,
+    outputFormat
   }) {
     this.arrayBufferPromise = fetchSpeechData({
       deploymentId,
-      getAuthorizationToken,
+      fetchAuthorizationTokenCredentials,
       lang: this.lang || window.navigator.language,
       outputFormat,
       pitch: this.pitch,
       rate: this.rate,
-      region,
       text: this.text,
       voice: this.voice && this.voice.voiceURI,
       volume: this.volume

--- a/packages/component/src/SpeechServices/TextToSpeech/fetchSpeechData.js
+++ b/packages/component/src/SpeechServices/TextToSpeech/fetchSpeechData.js
@@ -10,12 +10,11 @@ const SYNTHESIS_URL_TEMPLATE = 'https://{region}.tts.speech.microsoft.com/cognit
 
 export default async function ({
   deploymentId,
-  getAuthorizationToken,
+  fetchAuthorizationTokenCredentials,
   lang = DEFAULT_LANGUAGE,
   outputFormat,
   pitch,
   rate,
-  region,
   text,
   voice = DEFAULT_VOICE,
   volume
@@ -25,7 +24,7 @@ export default async function ({
     return decode(EMPTY_MP3_BASE64);
   }
 
-  const authorizationToken = await getAuthorizationToken();
+  const { authorizationToken, region } = await fetchAuthorizationTokenCredentials();
   const ssml = isSSML(text) ? text : buildSSML({ lang, pitch, rate, text, voice, volume });
 
   // Although calling encodeURI on hostname does not actually works, it fails faster and safer.

--- a/packages/component/src/SpeechServices/TextToSpeech/fetchVoices.js
+++ b/packages/component/src/SpeechServices/TextToSpeech/fetchVoices.js
@@ -2,7 +2,7 @@
 
 import SpeechSynthesisVoice from './SpeechSynthesisVoice';
 
-export default async function ({ authorizationToken, region }) {
+export default async function fetchVoices({ authorizationToken, region }) {
   // Although encodeURI on a hostname doesn't work as expected for hostname, at least, it will fail peacefully.
 
   const res = await fetch(

--- a/packages/component/src/SpeechServices/createFetchAuthorizationTokenWithCache.js
+++ b/packages/component/src/SpeechServices/createFetchAuthorizationTokenWithCache.js
@@ -1,0 +1,25 @@
+import memoize from 'memoize-one';
+
+import fetchAuthorizationToken from './fetchAuthorizationToken';
+
+// Based on this article, the token is expected to expire after 10 minutes.
+// https://docs.microsoft.com/en-us/azure/cognitive-services/authentication#authenticate-with-an-authentication-token
+
+const TOKEN_EARLY_RENEWAL = 60000;
+const TOKEN_EXPIRATION = 600000;
+
+export default function createCachedFetchAuthorizationToken() {
+  const fetchMemoizedAuthorizationToken = memoize(
+    (region, subscriptionKey) => fetchAuthorizationToken({ region, subscriptionKey }),
+    ([region, subscriptionKey, now], [prevRegion, prevSubscriptionKey, prevNow]) =>
+      region === prevRegion
+      && subscriptionKey === prevSubscriptionKey
+      && now - prevNow < TOKEN_EXPIRATION - TOKEN_EARLY_RENEWAL
+  );
+
+  return ({ region, subscriptionKey }) => fetchMemoizedAuthorizationToken(
+    region,
+    subscriptionKey,
+    Date.now()
+  );
+}

--- a/packages/component/src/SpeechServices/createFetchAuthorizationTokenWithCache.spec.js
+++ b/packages/component/src/SpeechServices/createFetchAuthorizationTokenWithCache.spec.js
@@ -1,0 +1,76 @@
+// jest.useFakeTimers() does not mock Date object, thus, we need to use Lolex.
+import { install as installLolex } from 'lolex';
+
+jest.mock('./fetchAuthorizationToken', () => jest.fn(async ({ subscriptionKey }) => `token:${ subscriptionKey }`));
+
+import createFetchAuthorizationTokenWithCache from './createFetchAuthorizationTokenWithCache';
+
+let clock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  clock = installLolex();
+});
+
+afterEach(() => {
+  clock.uninstall();
+});
+
+test('should return cached result after 1 minute', async () => {
+  const fetchAuthorizationToken = require('./fetchAuthorizationToken');
+  const fetchAuthorizationTokenWithCache = createFetchAuthorizationTokenWithCache();
+
+  await expect(fetchAuthorizationTokenWithCache({ region: 'westus', subscriptionKey: 'a1b2c3d' })).resolves.toBe('token:a1b2c3d');
+  expect(fetchAuthorizationToken).toHaveBeenCalledTimes(1);
+  expect(fetchAuthorizationToken).toHaveBeenCalledWith({ region: 'westus', subscriptionKey: 'a1b2c3d' });
+
+  clock.tick(60000);
+
+  await expect(fetchAuthorizationTokenWithCache({ region: 'westus', subscriptionKey: 'a1b2c3d' })).resolves.toBe('token:a1b2c3d');
+  expect(fetchAuthorizationToken).toHaveBeenCalledTimes(1);
+});
+
+test('should fetch new authorization token after 10 minutes', async () => {
+  const fetchAuthorizationToken = require('./fetchAuthorizationToken');
+  const fetchAuthorizationTokenWithCache = createFetchAuthorizationTokenWithCache();
+
+  await expect(fetchAuthorizationTokenWithCache({ region: 'westus', subscriptionKey: 'a1b2c3d' })).resolves.toBe('token:a1b2c3d');
+  expect(fetchAuthorizationToken).toHaveBeenCalledTimes(1);
+  expect(fetchAuthorizationToken).toHaveBeenCalledWith({ region: 'westus', subscriptionKey: 'a1b2c3d' });
+
+  clock.tick(600000);
+
+  await expect(fetchAuthorizationTokenWithCache({ region: 'westus', subscriptionKey: 'a1b2c3d' })).resolves.toBe('token:a1b2c3d');
+  expect(fetchAuthorizationToken).toHaveBeenCalledTimes(2);
+
+  clock.tick(60000);
+
+  await expect(fetchAuthorizationTokenWithCache({ region: 'westus', subscriptionKey: 'a1b2c3d' })).resolves.toBe('token:a1b2c3d');
+  expect(fetchAuthorizationToken).toHaveBeenCalledTimes(2);
+});
+
+test('should fetch new authorization token after region changed', async () => {
+  const fetchAuthorizationToken = require('./fetchAuthorizationToken');
+  const fetchAuthorizationTokenWithCache = createFetchAuthorizationTokenWithCache();
+
+  await expect(fetchAuthorizationTokenWithCache({ region: 'westus', subscriptionKey: 'a1b2c3d' })).resolves.toBe('token:a1b2c3d');
+  expect(fetchAuthorizationToken).toHaveBeenCalledTimes(1);
+  expect(fetchAuthorizationToken).toHaveBeenCalledWith({ region: 'westus', subscriptionKey: 'a1b2c3d' });
+
+  await expect(fetchAuthorizationTokenWithCache({ region: 'westus2', subscriptionKey: 'a1b2c3d' })).resolves.toBe('token:a1b2c3d');
+  expect(fetchAuthorizationToken).toHaveBeenCalledTimes(2);
+  expect(fetchAuthorizationToken).toHaveBeenCalledWith({ region: 'westus2', subscriptionKey: 'a1b2c3d' });
+});
+
+test('should fetch new authorization token after subscription key changed', async () => {
+  const fetchAuthorizationToken = require('./fetchAuthorizationToken');
+  const fetchAuthorizationTokenWithCache = createFetchAuthorizationTokenWithCache();
+
+  await expect(fetchAuthorizationTokenWithCache({ region: 'westus', subscriptionKey: 'a1b2c3d' })).resolves.toBe('token:a1b2c3d');
+  expect(fetchAuthorizationToken).toHaveBeenCalledTimes(1);
+  expect(fetchAuthorizationToken).toHaveBeenCalledWith({ region: 'westus', subscriptionKey: 'a1b2c3d' });
+
+  await expect(fetchAuthorizationTokenWithCache({ region: 'westus', subscriptionKey: 'd3c2b1a' })).resolves.toBe('token:d3c2b1a');
+  expect(fetchAuthorizationToken).toHaveBeenCalledTimes(2);
+  expect(fetchAuthorizationToken).toHaveBeenCalledWith({ region: 'westus', subscriptionKey: 'd3c2b1a' });
+});

--- a/packages/component/src/SpeechServices/patchOptions.credentials.spec.js
+++ b/packages/component/src/SpeechServices/patchOptions.credentials.spec.js
@@ -1,0 +1,140 @@
+import patchOptions from './patchOptions';
+
+let originalConsole;
+let logging = {};
+
+beforeEach(() => {
+  originalConsole = console;
+  console = {};
+
+  ['error', 'info', 'warn', 'log'].forEach(type => {
+    console[type] = (...args) => (logging[type] || (logging[type] = [])).push(args);
+  });
+});
+
+afterEach(() => {
+  console = originalConsole;
+});
+
+test('authorizationToken as string', async () => {
+  const options = patchOptions({ authorizationToken: 'a1b2c3d', region: 'westus2' });
+  const actual = options.fetchCredentials();
+
+  await expect(actual).resolves.toEqual({ authorizationToken: 'a1b2c3d', region: 'westus2' });
+});
+
+test('authorizationToken as Promise<string>', async () => {
+  const options = patchOptions({ authorizationToken: Promise.resolve('a1b2c3d'), region: 'westus2' });
+  const actual = options.fetchCredentials();
+
+  await expect(actual).resolves.toEqual({ authorizationToken: 'a1b2c3d', region: 'westus2' });
+});
+
+test('authorizationToken as () => string', async () => {
+  const options = patchOptions({ authorizationToken: () => 'a1b2c3d', region: 'westus2' });
+  const actual = options.fetchCredentials();
+
+  await expect(actual).resolves.toEqual({ authorizationToken: 'a1b2c3d', region: 'westus2' });
+});
+
+test('authorizationToken as () => Promise<string>', async () => {
+  const options = patchOptions({ authorizationToken: () => Promise.resolve('a1b2c3d'), region: 'westus2' });
+  const actual = options.fetchCredentials();
+
+  await expect(actual).resolves.toEqual({ authorizationToken: 'a1b2c3d', region: 'westus2' });
+});
+
+test('region should default to "westus"', async () => {
+  const options = patchOptions({ authorizationToken: 'a1b2c3d' });
+  const actual = options.fetchCredentials();
+
+  await expect(actual).resolves.toEqual({ authorizationToken: 'a1b2c3d', region: 'westus' });
+});
+
+test('subscriptionKey as string', async () => {
+  const options = patchOptions({ region: 'westus2', subscriptionKey: 'a1b2c3d' });
+  const actual = options.fetchCredentials();
+
+  await expect(actual).resolves.toEqual({ region: 'westus2', subscriptionKey: 'a1b2c3d' });
+});
+
+test('subscriptionKey as Promise<string>', async () => {
+  const options = patchOptions({ region: 'westus2', subscriptionKey: Promise.resolve('a1b2c3d') });
+  const actual = options.fetchCredentials();
+
+  await expect(actual).resolves.toEqual({ region: 'westus2', subscriptionKey: 'a1b2c3d' });
+});
+
+test('subscriptionKey as () => string', async () => {
+  const options = patchOptions({ region: 'westus2', subscriptionKey: () => 'a1b2c3d' });
+  const actual = options.fetchCredentials();
+
+  await expect(actual).resolves.toEqual({ region: 'westus2', subscriptionKey: 'a1b2c3d' });
+});
+
+test('subscriptionKey as () => Promise<string>', async () => {
+  const options = patchOptions({ region: 'westus2', subscriptionKey: () => Promise.resolve('a1b2c3d') });
+  const actual = options.fetchCredentials();
+
+  await expect(actual).resolves.toEqual({ region: 'westus2', subscriptionKey: 'a1b2c3d' });
+});
+
+test('should throw exception for authorizationKey as number', async () => {
+  const options = patchOptions({ authorizationToken: 123, region: 'westus2' });
+  const actual = options.fetchCredentials();
+
+  await expect(actual).rejects.toThrow();
+});
+
+test('should throw exception for authorizationKey as Promise<number>', async () => {
+  const options = patchOptions({ authorizationToken: Promise.resolve(123), region: 'westus2' });
+  const actual = options.fetchCredentials();
+
+  await expect(actual).rejects.toThrow();
+});
+
+test('should throw exception for authorizationKey as () => number', async () => {
+  const options = patchOptions({ authorizationToken: () => 123, region: 'westus2' });
+  const actual = options.fetchCredentials();
+
+  await expect(actual).rejects.toThrow();
+});
+
+test('should throw exception for authorizationKey as () => Promise<number>', async () => {
+  const options = patchOptions({ authorizationToken: () => Promise.resolve(123), region: 'westus2' });
+  const actual = options.fetchCredentials();
+
+  await expect(actual).rejects.toThrow();
+});
+
+test('should throw exception for subscriptionKey as number', async () => {
+  const options = patchOptions({ region: 'westus2', subscriptionKey: 123 });
+  const actual = options.fetchCredentials();
+
+  await expect(actual).rejects.toThrow();
+});
+
+test('should throw exception for subscriptionKey as Promise<number>', async () => {
+  const options = patchOptions({ region: 'westus2', subscriptionKey: Promise.resolve(123) });
+  const actual = options.fetchCredentials();
+
+  await expect(actual).rejects.toThrow();
+});
+
+test('should throw exception for subscriptionKey as () => number', async () => {
+  const options = patchOptions({ region: 'westus2', subscriptionKey: () => 123 });
+  const actual = options.fetchCredentials();
+
+  await expect(actual).rejects.toThrow();
+});
+
+test('should throw exception for subscriptionKey as () => Promise<number>', async () => {
+  const options = patchOptions({ region: 'westus2', subscriptionKey: () => Promise.resolve(123) });
+  const actual = options.fetchCredentials();
+
+  await expect(actual).rejects.toThrow();
+});
+
+test('should throw exception when authorizationToken and subscriptionKey are not specified', async () => {
+  expect(() => patchOptions({ region: 'westus2' })).toThrow();
+});

--- a/packages/component/src/SpeechServices/patchOptions.js
+++ b/packages/component/src/SpeechServices/patchOptions.js
@@ -1,0 +1,66 @@
+import resolveFunctionOrReturnValue from './resolveFunctionOrReturnValue';
+
+let shouldWarnOnSubscriptionKey = true;
+
+export default function patchOptions({
+  authorizationToken,
+  credentials,
+  looseEvent,
+  looseEvents,
+  region = 'westus',
+  subscriptionKey,
+  ...otherOptions
+} = {}) {
+  if (typeof looseEvent !== 'undefined') {
+    console.warn('web-speech-cognitive-services: The option "looseEvent" should be named as "looseEvents".');
+
+    looseEvents = looseEvent;
+  }
+
+  if (!credentials) {
+    if (!authorizationToken && !subscriptionKey) {
+      throw new Error('web-speech-cognitive-services: Credentials must be specified.');
+    } else {
+      console.warn('web-speech-cognitive-services: We are deprecating authorizationToken, region, and subscriptionKey. Please use credentials instead. The deprecated option will be removed on or after 2020-11-14.');
+
+      credentials = async () =>
+        authorizationToken ?
+          { authorizationToken: await resolveFunctionOrReturnValue(authorizationToken), region }
+        :
+          { region, subscriptionKey: await resolveFunctionOrReturnValue(subscriptionKey) };
+    }
+  }
+
+  return {
+    ...otherOptions,
+    fetchCredentials: async () => {
+      const { authorizationToken, region, subscriptionKey } = await resolveFunctionOrReturnValue(credentials);
+
+      if (!authorizationToken && !subscriptionKey) {
+        throw new Error('web-speech-cognitive-services: Either authorization token and subscription key must be provided.');
+      }
+
+      if (authorizationToken) {
+        if (typeof authorizationToken !== 'string') {
+          throw new Error('web-speech-cognitive-services: Authorization token must be a string.');
+        }
+      } else if (typeof subscriptionKey !== 'string') {
+        throw new Error('web-speech-cognitive-services: Subscription key must be a string.');
+      }
+
+      if (shouldWarnOnSubscriptionKey && subscriptionKey) {
+        console.warn('web-speech-cognitive-services: In production environment, subscription key should not be used, authorization token should be used instead.');
+
+        shouldWarnOnSubscriptionKey = false;
+      }
+
+      return (
+        authorizationToken ?
+          { authorizationToken, region }
+        :
+          { region, subscriptionKey }
+      );
+    },
+    looseEvents
+  };
+}

--- a/packages/component/src/SpeechServices/resolveFunctionOrReturnValue.js
+++ b/packages/component/src/SpeechServices/resolveFunctionOrReturnValue.js
@@ -1,0 +1,3 @@
+export default async function resolveFunctionOrReturnValue(fnOrValue) {
+  return await (typeof fnOrValue === 'function' ? fnOrValue() : fnOrValue);
+}

--- a/packages/component/src/SpeechServices/resolveFunctionOrReturnValue.js
+++ b/packages/component/src/SpeechServices/resolveFunctionOrReturnValue.js
@@ -1,3 +1,3 @@
-export default async function resolveFunctionOrReturnValue(fnOrValue) {
-  return await (typeof fnOrValue === 'function' ? fnOrValue() : fnOrValue);
+export default function resolveFunctionOrReturnValue(fnOrValue) {
+  return typeof fnOrValue === 'function' ? fnOrValue() : fnOrValue;
 }

--- a/packages/component/src/SpeechServices/resolveFunctionOrReturnValue.spec.js
+++ b/packages/component/src/SpeechServices/resolveFunctionOrReturnValue.spec.js
@@ -1,15 +1,15 @@
 import resolveFunctionOrReturnValue from './resolveFunctionOrReturnValue';
 
-test('resolve sync function', async () => {
-  await expect(resolveFunctionOrReturnValue(() => 1)).resolves.toBe(1);
+test('resolve sync function', () => {
+  expect(resolveFunctionOrReturnValue(() => 1)).toBe(1);
 });
 
 test('resolve async function', async () => {
   await expect(resolveFunctionOrReturnValue(() => Promise.resolve(1))).resolves.toBe(1);
 });
 
-test('return sync value', async () => {
-  await expect(resolveFunctionOrReturnValue(1)).resolves.toBe(1);
+test('return sync value', () => {
+  expect(resolveFunctionOrReturnValue(1)).toBe(1);
 });
 
 test('return async value', async () => {

--- a/packages/component/src/SpeechServices/resolveFunctionOrReturnValue.spec.js
+++ b/packages/component/src/SpeechServices/resolveFunctionOrReturnValue.spec.js
@@ -1,0 +1,17 @@
+import resolveFunctionOrReturnValue from './resolveFunctionOrReturnValue';
+
+test('resolve sync function', async () => {
+  await expect(resolveFunctionOrReturnValue(() => 1)).resolves.toBe(1);
+});
+
+test('resolve async function', async () => {
+  await expect(resolveFunctionOrReturnValue(() => Promise.resolve(1))).resolves.toBe(1);
+});
+
+test('return sync value', async () => {
+  await expect(resolveFunctionOrReturnValue(1)).resolves.toBe(1);
+});
+
+test('return async value', async () => {
+  await expect(resolveFunctionOrReturnValue(Promise.resolve(1))).resolves.toBe(1);
+});


### PR DESCRIPTION
## Description

Before this change, we only support asynchronously setting authorization token, but not for Azure region. Thus, if you have multiple subscription keys used in different Azure regions, it is not trivial to renew the authentication token while moving to another Azure region.

In this PR, we unified all credentials options into a single option namely `credentials`. It inherits previous signature which support Promise-based function or simple objects.

You can use the new `credentials` object to set the Azure region, and your choice of either authorization token or subscription key.

## Changelog

### Breaking changes

#### Unifying options to pass credentials

`authorizationToken`, `region`, and `subscriptionKey` are being deprecated in favor of `credentials` options. `credentials` can be one of the following types:

- `{ authorizationToken: string, region: string? }`
- `{ region: string?, subscriptionKey: string }`
- `Promise<{ authorizationToken: string, region: string? }>`
- `Promise<{ region: string?, subscriptionKey: string }>`
- `() => { authorizationToken: string, region: string? }`
- `() => { region: string?, subscriptionKey: string }`
- `() => Promise<{ authorizationToken: string, region: string? }>`
- `() => Promise<{ region: string?, subscriptionKey: string }>`

If `credentials` is a function, it will be called just before the credentials is needed and may be called very frequently. This behavior matches the deprecating `authorizationToken`. The result of the call is also expected to be cached.

If `region` is not returned, the default value of `"westus"` will be used.

### Removed

- 🔥 `authorizationToken`, `region`, and `subscriptionKey` are being deprecated in favor of `credentials` options, by [@compulim](https://github.com/compulim) in PR [#80](https://github.com/compulim/web-speech-cognitive-services/pull/80)

### Added

- `credentials` option is added for obtaining authorization token and region, or subscription key and region, in a single object or function call, by [@compulim](https://github.com/compulim) in PR [#80](https://github.com/compulim/web-speech-cognitive-services/pull/80)
