### PR TITLE
Move `microsoft-cognitiveservices-speech-sdk` to `peerDependencies`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Breaking changes
+
+- To enable developers to select their version of Cognitive Services Speech SDK and use newer features, we are moving [`microsoft-cognitiveservices-speech-sdk`](https://npmjs.com/package/microsoft-cognitiveservices-speech-sdk) to `peerDependencies`.
+   - When you install `web-speech-cognitive-services`, you will also need to install a compatible version of `microsoft-cognitiveservices-speech-sdk`.
+
+### Changed
+
+- Fixes [#96](https://github.com/compulim/web-speech-cognitive-services/issues/96), move [`microsoft-cognitiveservices-speech-sdk`](https://npmjs.com/package/microsoft-cognitive-services-speech-sdk) to `peerDependencies`, by [@compulim](https://github.com/compulim), in PR [#97](https://github.com/compulim/web-speech-cognitive-services/pull/97)
+
 ## [6.3.0] - 2020-03-28
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "6.3.1-0",
+  "version": "7.0.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "6.3.1-0",
+  "version": "7.0.0-0",
   "description": "",
   "private": true,
   "scripts": {

--- a/packages/bundle/package-lock.json
+++ b/packages/bundle/package-lock.json
@@ -1255,6 +1255,15 @@
 			"integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
 			"dev": true
 		},
+		"agent-base": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+			"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+			"dev": true,
+			"requires": {
+				"es6-promisify": "^5.0.0"
+			}
+		},
 		"ajv": {
 			"version": "6.10.2",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
@@ -1392,6 +1401,38 @@
 				"bn.js": "^4.0.0",
 				"inherits": "^2.0.1",
 				"minimalistic-assert": "^1.0.0"
+			}
+		},
+		"asn1.js-rfc2560": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/asn1.js-rfc2560/-/asn1.js-rfc2560-5.0.1.tgz",
+			"integrity": "sha512-1PrVg6kuBziDN3PGFmRk3QrjpKvP9h/Hv5yMrFZvC1kpzP6dQRzf5BpKstANqHBkaOUmTpakJWhicTATOA/SbA==",
+			"dev": true,
+			"requires": {
+				"asn1.js-rfc5280": "^3.0.0"
+			}
+		},
+		"asn1.js-rfc5280": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/asn1.js-rfc5280/-/asn1.js-rfc5280-3.0.0.tgz",
+			"integrity": "sha512-Y2LZPOWeZ6qehv698ZgOGGCZXBQShObWnGthTrIFlIQjuV1gg2B8QOhWFRExq/MR1VnPpIIe7P9vX2vElxv+Pg==",
+			"dev": true,
+			"requires": {
+				"asn1.js": "^5.0.0"
+			},
+			"dependencies": {
+				"asn1.js": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.3.0.tgz",
+					"integrity": "sha512-WHnQJFcOrIWT1RLOkFFBQkFVvyt9BPOOrH+Dp152Zk4R993rSzXUGPmkybIcUFhHE2d/iHH+nCaOWVCDbO8fgA==",
+					"dev": true,
+					"requires": {
+						"bn.js": "^4.0.0",
+						"inherits": "^2.0.1",
+						"minimalistic-assert": "^1.0.0",
+						"safer-buffer": "^2.1.0"
+					}
+				}
 			}
 		},
 		"assert": {
@@ -2420,6 +2461,21 @@
 			"dev": true,
 			"requires": {
 				"is-arrayish": "^0.2.1"
+			}
+		},
+		"es6-promise": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+			"dev": true
+		},
+		"es6-promisify": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+			"dev": true,
+			"requires": {
+				"es6-promise": "^4.0.3"
 			}
 		},
 		"escape-string-regexp": {
@@ -3742,6 +3798,33 @@
 			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
 			"dev": true
 		},
+		"https-proxy-agent": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
+			"integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
+			"dev": true,
+			"requires": {
+				"agent-base": "^4.3.0",
+				"debug": "^3.1.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				}
+			}
+		},
 		"iconv-lite": {
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -4443,6 +4526,19 @@
 				"regex-not": "^1.0.0",
 				"snapdragon": "^0.8.1",
 				"to-regex": "^3.0.2"
+			}
+		},
+		"microsoft-cognitiveservices-speech-sdk": {
+			"version": "1.10.1",
+			"resolved": "https://registry.npmjs.org/microsoft-cognitiveservices-speech-sdk/-/microsoft-cognitiveservices-speech-sdk-1.10.1.tgz",
+			"integrity": "sha512-uqtNe5p1Un6hXUse9pDGvk7p6QZ96t7YzWaTmmDeaL1eIbrXAPBK4ecTE7OR0JCfLlRcJFfnRJtNO+itdLD3ZQ==",
+			"dev": true,
+			"requires": {
+				"asn1.js-rfc2560": "^5.0.1",
+				"asn1.js-rfc5280": "^3.0.0",
+				"https-proxy-agent": "^3.0.1",
+				"simple-lru-cache": "0.0.2",
+				"ws": "^7.2.1"
 			}
 		},
 		"miller-rabin": {
@@ -5558,6 +5654,12 @@
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 			"dev": true
 		},
+		"simple-lru-cache": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz",
+			"integrity": "sha1-1ZzDoZPBpdAyD4Tucy9uRxPlEd0=",
+			"dev": true
+		},
 		"slash": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
@@ -6650,6 +6752,12 @@
 			"requires": {
 				"mkdirp": "^0.5.1"
 			}
+		},
+		"ws": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
+			"integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==",
+			"dev": true
 		},
 		"xtend": {
 			"version": "4.0.2",

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -29,6 +29,7 @@
     "@babel/preset-react": "^7.8.3",
     "concurrently": "^4.1.2",
     "eslint": "^6.8.0",
+    "microsoft-cognitiveservices-speech-sdk": "1.10.1",
     "rimraf": "^2.6.3",
     "webpack": "^4.42.0",
     "webpack-cli": "^3.3.11",

--- a/packages/component/package-lock.json
+++ b/packages/component/package-lock.json
@@ -3598,6 +3598,7 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
 			"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+			"dev": true,
 			"requires": {
 				"es6-promisify": "^5.0.0"
 			}
@@ -3966,6 +3967,7 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.3.0.tgz",
 			"integrity": "sha512-WHnQJFcOrIWT1RLOkFFBQkFVvyt9BPOOrH+Dp152Zk4R993rSzXUGPmkybIcUFhHE2d/iHH+nCaOWVCDbO8fgA==",
+			"dev": true,
 			"requires": {
 				"bn.js": "^4.0.0",
 				"inherits": "^2.0.1",
@@ -3977,6 +3979,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/asn1.js-rfc2560/-/asn1.js-rfc2560-5.0.1.tgz",
 			"integrity": "sha512-1PrVg6kuBziDN3PGFmRk3QrjpKvP9h/Hv5yMrFZvC1kpzP6dQRzf5BpKstANqHBkaOUmTpakJWhicTATOA/SbA==",
+			"dev": true,
 			"requires": {
 				"asn1.js-rfc5280": "^3.0.0"
 			}
@@ -3985,6 +3988,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/asn1.js-rfc5280/-/asn1.js-rfc5280-3.0.0.tgz",
 			"integrity": "sha512-Y2LZPOWeZ6qehv698ZgOGGCZXBQShObWnGthTrIFlIQjuV1gg2B8QOhWFRExq/MR1VnPpIIe7P9vX2vElxv+Pg==",
+			"dev": true,
 			"requires": {
 				"asn1.js": "^5.0.0"
 			}
@@ -5710,12 +5714,14 @@
 		"es6-promise": {
 			"version": "4.2.8",
 			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+			"dev": true
 		},
 		"es6-promisify": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
 			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+			"dev": true,
 			"requires": {
 				"es6-promise": "^4.0.3"
 			}
@@ -7181,6 +7187,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
 			"integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
+			"dev": true,
 			"requires": {
 				"agent-base": "^4.3.0",
 				"debug": "^3.1.0"
@@ -7190,6 +7197,7 @@
 					"version": "3.2.6",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
 					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -7197,7 +7205,8 @@
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
 				}
 			}
 		},
@@ -9553,15 +9562,16 @@
 			}
 		},
 		"microsoft-cognitiveservices-speech-sdk": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/microsoft-cognitiveservices-speech-sdk/-/microsoft-cognitiveservices-speech-sdk-1.9.1.tgz",
-			"integrity": "sha512-x6FSGjgx02U//D4HUjVN6JIkEMrCbAECM+mfcPYkjEmymag5IIy30RAQJYwNoCeHTZS7wWURkiW7rrHGIymzJg==",
+			"version": "1.10.1",
+			"resolved": "https://registry.npmjs.org/microsoft-cognitiveservices-speech-sdk/-/microsoft-cognitiveservices-speech-sdk-1.10.1.tgz",
+			"integrity": "sha512-uqtNe5p1Un6hXUse9pDGvk7p6QZ96t7YzWaTmmDeaL1eIbrXAPBK4ecTE7OR0JCfLlRcJFfnRJtNO+itdLD3ZQ==",
+			"dev": true,
 			"requires": {
-				"asn1.js-rfc2560": "^5.0.0",
+				"asn1.js-rfc2560": "^5.0.1",
 				"asn1.js-rfc5280": "^3.0.0",
 				"https-proxy-agent": "^3.0.1",
 				"simple-lru-cache": "0.0.2",
-				"ws": "^7.2.0"
+				"ws": "^7.2.1"
 			}
 		},
 		"miller-rabin": {
@@ -10809,7 +10819,8 @@
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
 		},
 		"sane": {
 			"version": "4.1.0",
@@ -10948,7 +10959,8 @@
 		"simple-lru-cache": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz",
-			"integrity": "sha1-1ZzDoZPBpdAyD4Tucy9uRxPlEd0="
+			"integrity": "sha1-1ZzDoZPBpdAyD4Tucy9uRxPlEd0=",
+			"dev": true
 		},
 		"simple-update-in": {
 			"version": "2.1.1",
@@ -12241,7 +12253,8 @@
 		"ws": {
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
-			"integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ=="
+			"integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==",
+			"dev": true
 		},
 		"xml-name-validator": {
 			"version": "3.0.0",

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -59,6 +59,7 @@
     "global-agent": "^2.1.8",
     "jest": "^25.1.0",
     "lolex": "^5.1.2",
+    "microsoft-cognitiveservices-speech-sdk": "1.10.1",
     "node-fetch": "^2.6.0",
     "prettier": "^1.19.1",
     "rimraf": "^3.0.2"
@@ -70,10 +71,12 @@
     "event-target-shim": "^5.0.1",
     "event-target-shim-es5": "^1.0.1",
     "memoize-one": "^5.1.1",
-    "microsoft-cognitiveservices-speech-sdk": "1.9.1",
     "on-error-resume-next": "^1.1.0",
     "p-defer": "^3.0.0",
     "p-defer-es5": "^1.0.1",
     "simple-update-in": "^2.1.1"
+  },
+  "peerDependencies": {
+    "microsoft-cognitiveservices-speech-sdk": "~1.10.1"
   }
 }

--- a/packages/playground/package-lock.json
+++ b/packages/playground/package-lock.json
@@ -1881,6 +1881,14 @@
         }
       }
     },
+    "agent-base": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      }
+    },
     "aggregate-error": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
@@ -2078,6 +2086,35 @@
         "bn.js": "^4.0.0",
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "asn1.js-rfc2560": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/asn1.js-rfc2560/-/asn1.js-rfc2560-5.0.1.tgz",
+      "integrity": "sha512-1PrVg6kuBziDN3PGFmRk3QrjpKvP9h/Hv5yMrFZvC1kpzP6dQRzf5BpKstANqHBkaOUmTpakJWhicTATOA/SbA==",
+      "requires": {
+        "asn1.js-rfc5280": "^3.0.0"
+      }
+    },
+    "asn1.js-rfc5280": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/asn1.js-rfc5280/-/asn1.js-rfc5280-3.0.0.tgz",
+      "integrity": "sha512-Y2LZPOWeZ6qehv698ZgOGGCZXBQShObWnGthTrIFlIQjuV1gg2B8QOhWFRExq/MR1VnPpIIe7P9vX2vElxv+Pg==",
+      "requires": {
+        "asn1.js": "^5.0.0"
+      },
+      "dependencies": {
+        "asn1.js": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.3.0.tgz",
+          "integrity": "sha512-WHnQJFcOrIWT1RLOkFFBQkFVvyt9BPOOrH+Dp152Zk4R993rSzXUGPmkybIcUFhHE2d/iHH+nCaOWVCDbO8fgA==",
+          "requires": {
+            "bn.js": "^4.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "safer-buffer": "^2.1.0"
+          }
+        }
       }
     },
     "assert": {
@@ -4406,6 +4443,19 @@
         "es6-symbol": "^3.1.1"
       }
     },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "^4.0.3"
+      }
+    },
     "es6-symbol": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
@@ -6150,6 +6200,25 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
+    },
+    "https-proxy-agent": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
+      "integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
+      "requires": {
+        "agent-base": "^4.3.0",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
     },
     "hyphenate-style-name": {
       "version": "1.0.2",
@@ -8323,6 +8392,25 @@
           "version": "6.0.3",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
           "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+        }
+      }
+    },
+    "microsoft-cognitiveservices-speech-sdk": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/microsoft-cognitiveservices-speech-sdk/-/microsoft-cognitiveservices-speech-sdk-1.10.1.tgz",
+      "integrity": "sha512-uqtNe5p1Un6hXUse9pDGvk7p6QZ96t7YzWaTmmDeaL1eIbrXAPBK4ecTE7OR0JCfLlRcJFfnRJtNO+itdLD3ZQ==",
+      "requires": {
+        "asn1.js-rfc2560": "^5.0.1",
+        "asn1.js-rfc5280": "^3.0.0",
+        "https-proxy-agent": "^3.0.1",
+        "simple-lru-cache": "0.0.2",
+        "ws": "^7.2.1"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
+          "integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ=="
         }
       }
     },
@@ -11757,6 +11845,11 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "simple-lru-cache": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz",
+      "integrity": "sha1-1ZzDoZPBpdAyD4Tucy9uRxPlEd0="
     },
     "simple-swizzle": {
       "version": "0.2.2",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "classnames": "^2.2.6",
     "glamor": "^2.20.40",
+    "microsoft-cognitiveservices-speech-sdk": "1.10.1",
     "on-error-resume-next": "^1.1.0",
     "p-defer": "^3.0.0",
     "p-defer-es5": "^1.0.1",


### PR DESCRIPTION
## Changelog

### Breaking changes

- To enable developers to select their version of Cognitive Services Speech SDK and use newer features, we are moving [`microsoft-cognitiveservices-speech-sdk`](https://npmjs.com/package/microsoft-cognitiveservices-speech-sdk) to `peerDependencies`.
   - When you install `web-speech-cognitive-services`, you will also need to install a compatible version of `microsoft-cognitiveservices-speech-sdk`.

### Changed

- Fixes [#96](https://github.com/compulim/web-speech-cognitive-services/issues/96), move [`microsoft-cognitiveservices-speech-sdk`](https://npmjs.com/package/microsoft-cognitive-services-speech-sdk) to `peerDependencies`, by [@compulim](https://github.com/compulim), in PR [#97](https://github.com/compulim/web-speech-cognitive-services/pull/97)
