### PR TITLE
Add upload release asset workflow

### DIFF
--- a/.github/workflows/upload-release-asset.yml
+++ b/.github/workflows/upload-release-asset.yml
@@ -1,0 +1,22 @@
+name: Upload release asset
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version
+        required: true
+        type: string
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download tarball
+        run: curl -LO `npm view --json web-speech-cognitive-services@${{ inputs.version }} | jq -r .dist.tarball`
+
+      - name: Upload
+        uses: softprops/action-gh-release@v1
+        with:
+          files: web-speech-cognitive-services-${{ inputs.version }}.tgz
+          tag_name: v${{ inputs.version }}


### PR DESCRIPTION
Add `upload-release-asset.yml` workflow. When manually triggered, it will download tarball from NPM and upload as part of a release.