### PR TITLE
Don't publish to pages on tags

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -200,7 +200,7 @@ jobs:
           asset_content_type: application/octet-stream
 
   deploy-pages:
-    if: ${{ startsWith(github.ref, 'refs/heads/') || startsWith(github.ref, 'refs/tags/') }}
+    if: ${{ startsWith(github.ref, 'refs/heads/') }}
     needs: build
 
     permissions:


### PR DESCRIPTION
The `github-pages` environment is protected for `master` only and not `refs/tags/*`.