### PR TITLE
Fix continuous mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed [#218](https://github.com/compulim/web-speech-cognitive-services/issues/218). Speech recognition should stopping properly in some cases, in PR [#218](https://github.com/compulim/web-speech-cognitive-services/pull/219)
    - Interactive mode, muted microphone
    - Continuous and interactive mode, stop shortly after start
+- Fixed [#221](https://github.com/compulim/web-speech-cognitive-services/issues/221). Continuous mode with successful interims should stop without errors, in PR [#XXX](https://github.com/compulim/web-speech-cognitive-services/pull/XXX]
 
 ### Changed
 

--- a/packages/web-speech-cognitive-services/src/SpeechServices/SpeechToText/createSpeechRecognitionPonyfill.js
+++ b/packages/web-speech-cognitive-services/src/SpeechServices/SpeechToText/createSpeechRecognitionPonyfill.js
@@ -519,7 +519,7 @@ export function createSpeechRecognitionPonyfillFromRecognizer({
               //   That means, we need to end this manually in interactive mode, and continuous-but-stopping mode.
               if (!this.continuous || stopping === 'stop') {
                 // Empty result will turn into "no-speech" later in the code.
-                finalEvent = new SpeechRecognitionEvent('result');
+                finalEvent = new SpeechRecognitionEvent('result', { results: finalizedResults });
 
                 // Quirks: 2024-11-19 with Speech SDK 1.14.0
                 //   Speech SDK did not stop after NoMatch even in interactive mode.


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Fixed

- Fixed [#221](https://github.com/compulim/web-speech-cognitive-services/issues/221). Continuous mode with successful interims should stop without errors, in PR [#XXX](https://github.com/compulim/web-speech-cognitive-services/pull/XXX]

## Specific changes

> Please list each individual specific change in this pull request.

- Stopping continuous mode should repeat last `result` event