### PR TITLE
Fix entrypoint types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- 💥 Modernized some code with TypeScript, more type-aligned to W3C Speech API, and moved to official Event Target API, in PR [#220](https://github.com/compulim/web-speech-cognitive-services/pull/220), [#224](https://github.com/compulim/web-speech-cognitive-services/pull/224), [#225](https://github.com/compulim/web-speech-cognitive-services/pull/225), and [#XXX](https://github.com/compulim/web-speech-cognitive-services/pull/XXX)
+- 💥 Modernized some code with TypeScript, more type-aligned to W3C Speech API, and moved to official Event Target API, in PR [#220](https://github.com/compulim/web-speech-cognitive-services/pull/220), [#224](https://github.com/compulim/web-speech-cognitive-services/pull/224), [#225](https://github.com/compulim/web-speech-cognitive-services/pull/225), and [#228](https://github.com/compulim/web-speech-cognitive-services/pull/228)
    -  `SpeechRecognitionResult` and `SpeechRecognitionResultList` is now a array-like object, use `Array.from()` to convert them into an array
 - Updated build tools and added named exports via CJS/ESM
 - Bumped dependencies, in PR [#216](https://github.com/compulim/web-speech-cognitive-services/pull/216) and [#218](https://github.com/compulim/web-speech-cognitive-services/issues/218)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- 💥 Modernized some code with TypeScript, more type-aligned to W3C Speech API, and moved to official Event Target API, in PR [#220](https://github.com/compulim/web-speech-cognitive-services/pull/220), [#224](https://github.com/compulim/web-speech-cognitive-services/pull/224) and [#225](https://github.com/compulim/web-speech-cognitive-services/pull/225)
+- 💥 Modernized some code with TypeScript, more type-aligned to W3C Speech API, and moved to official Event Target API, in PR [#220](https://github.com/compulim/web-speech-cognitive-services/pull/220), [#224](https://github.com/compulim/web-speech-cognitive-services/pull/224), [#225](https://github.com/compulim/web-speech-cognitive-services/pull/225), and [#XXX](https://github.com/compulim/web-speech-cognitive-services/pull/XXX)
    -  `SpeechRecognitionResult` and `SpeechRecognitionResultList` is now a array-like object, use `Array.from()` to convert them into an array
 - Updated build tools and added named exports via CJS/ESM
 - Bumped dependencies, in PR [#216](https://github.com/compulim/web-speech-cognitive-services/pull/216) and [#218](https://github.com/compulim/web-speech-cognitive-services/issues/218)

--- a/packages/web-speech-cognitive-services/src/SpeechServices.ts
+++ b/packages/web-speech-cognitive-services/src/SpeechServices.ts
@@ -15,7 +15,7 @@ import createSpeechSynthesisPonyfill from './SpeechServices/TextToSpeech';
 import fetchAuthorizationToken from './SpeechServices/fetchAuthorizationToken';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default function createSpeechServicesPonyfill(options: any = {}) {
+export default function createSpeechServicesPonyfill(options: any = {}): any {
   return {
     ...createSpeechRecognitionPonyfill(options),
     ...createSpeechSynthesisPonyfill(options)

--- a/packages/web-speech-cognitive-services/src/SpeechServices/SpeechToText/SpeechGrammarList.ts
+++ b/packages/web-speech-cognitive-services/src/SpeechServices/SpeechToText/SpeechGrammarList.ts
@@ -1,6 +1,19 @@
+interface W3CSpeechGrammar {
+  src: string;
+  weight: number;
+}
+
+interface W3CSpeechGrammarList {
+  readonly length: number;
+  addFromString(string: string, weight?: number): void;
+  addFromURI(src: string, weight?: number): void;
+  item(index: number): W3CSpeechGrammar;
+  [index: number]: W3CSpeechGrammar;
+}
+
 /* eslint class-methods-use-this: "off" */
 
-export default class SpeechGrammarList {
+export default class SpeechGrammarList implements W3CSpeechGrammarList {
   constructor() {
     this.#phrases = [];
   }
@@ -8,6 +21,20 @@ export default class SpeechGrammarList {
   addFromString() {
     throw new Error('JSGF is not supported');
   }
+
+  addFromURI() {
+    throw new Error('JSGF is not supported');
+  }
+
+  item(): W3CSpeechGrammar {
+    throw new Error('JSGF is not supported');
+  }
+
+  get length(): number {
+    throw new Error('JSGF is not supported');
+  }
+
+  [index: number]: { src: string; weight: number };
 
   #phrases: readonly string[];
 


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Changed

- 💥 Modernized some code with TypeScript, more type-aligned to W3C Speech API, and moved to official Event Target API, in PR [#220](https://github.com/compulim/web-speech-cognitive-services/pull/220), [#224](https://github.com/compulim/web-speech-cognitive-services/pull/224), [#225](https://github.com/compulim/web-speech-cognitive-services/pull/225), and [#228](https://github.com/compulim/web-speech-cognitive-services/pull/228)
   -  `SpeechRecognitionResult` and `SpeechRecognitionResultList` is now a array-like object, use `Array.from()` to convert them into an array

## Specific changes

> Please list each individual specific change in this pull request.

- Updated return type of `createSpeechServicesPonyfill` to `any` until we have TTS typing ready