### PR TITLE
Bump on-error-resume-next@2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Bumped dependencies, in PR [#XXX](https://github.com/compulim/web-speech-cognitive-services/pull/XXX)
+- Bumped dependencies, in PR [#238](https://github.com/compulim/web-speech-cognitive-services/pull/238)
    -  Production dependencies
       - [`on-error-resume-next@2.0.2`](https://npmjs.com/package/on-error-resume-next/v/2.0.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Bumped dependencies, in PR [#XXX](https://github.com/compulim/web-speech-cognitive-services/pull/XXX)
+   -  Production dependencies
+      - [`on-error-resume-next@2.0.2`](https://npmjs.com/package/on-error-resume-next/v/2.0.2)
+
 ## [8.1.0] - 2025-01-06
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -9739,11 +9739,12 @@
       }
     },
     "node_modules/on-error-resume-next": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/on-error-resume-next/-/on-error-resume-next-2.0.1.tgz",
-      "integrity": "sha512-TWop/Bivr/7/JC0zLlYqqfGTiMnsRYHCIPdZuwWvMbHQtphW0x2PJ5WeAKleji64jXlOKUOpDsniXJkghH1nXA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/on-error-resume-next/-/on-error-resume-next-2.0.2.tgz",
+      "integrity": "sha512-xGi+R6gp5OyWz/BbGIxyXbdcaGl0SFjvCyC0HgquupNC5t15L+7B/KYwLQ47EPRfpegmX0uOa85GAj4NO4Ujlg==",
+      "license": "MIT",
       "dependencies": {
-        "on-error-resume-next": "^2.0.1"
+        "on-error-resume-next": "^2.0.2"
       }
     },
     "node_modules/once": {
@@ -12543,7 +12544,7 @@
         "event-as-promise": "^2.0.0",
         "event-target-shim": "^6.0.2",
         "memoize-one": "^6.0.0",
-        "on-error-resume-next": "^2.0.1",
+        "on-error-resume-next": "^2.0.2",
         "simple-update-in": "^2.2.0",
         "valibot": "^0.42.1"
       },

--- a/packages/web-speech-cognitive-services/package.json
+++ b/packages/web-speech-cognitive-services/package.json
@@ -98,7 +98,7 @@
     "event-as-promise": "^2.0.0",
     "event-target-shim": "^6.0.2",
     "memoize-one": "^6.0.0",
-    "on-error-resume-next": "^2.0.1",
+    "on-error-resume-next": "^2.0.2",
     "simple-update-in": "^2.2.0",
     "valibot": "^0.42.1"
   },


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Changed

- Bumped dependencies, in PR [#238](https://github.com/compulim/web-speech-cognitive-services/pull/238)
   -  Production dependencies
      - [`on-error-resume-next@2.0.2`](https://npmjs.com/package/on-error-resume-next/v/2.0.2)

## Specific changes

> Please list each individual specific change in this pull request.

- Bump to `on-erro-resume-next@2.0.2` which provide backward compatibility with Webpack 4