### PR TITLE
Add import file extensions for file-based import for Speech SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Fixed import of Speech SDK with file extension to resolve build breaks with `create-react-app`, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/compulim/web-speech-cognitive-services/pull/XXX)
+- Fixed import of Speech SDK with file extension to resolve build breaks with `create-react-app`, by [@compulim](https://github.com/compulim), in PR [#243](https://github.com/compulim/web-speech-cognitive-services/pull/243)
 
 ## [8.1.1] - 2025-01-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed import of Speech SDK with file extension to resolve build breaks with `create-react-app`, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/compulim/web-speech-cognitive-services/pull/XXX)
+
 ## [8.1.1] - 2025-01-21
 
 ### Changed

--- a/packages/web-speech-cognitive-services/src/SpeechServices/SpeechSDK.ts
+++ b/packages/web-speech-cognitive-services/src/SpeechServices/SpeechSDK.ts
@@ -6,7 +6,7 @@ import {
   ResultReason,
   SpeechConfig,
   SpeechRecognizer
-} from 'microsoft-cognitiveservices-speech-sdk/distrib/lib/microsoft.cognitiveservices.speech.sdk';
+} from 'microsoft-cognitiveservices-speech-sdk/distrib/lib/microsoft.cognitiveservices.speech.sdk.js';
 
 export default {
   AudioConfig,

--- a/packages/web-speech-cognitive-services/src/SpeechServices/SpeechToText/createSpeechRecognitionPonyfillFromRecognizer.ts
+++ b/packages/web-speech-cognitive-services/src/SpeechServices/SpeechToText/createSpeechRecognitionPonyfillFromRecognizer.ts
@@ -11,7 +11,7 @@ import {
   type SpeechRecognitionEventArgs,
   type SpeechRecognizer as SpeechRecognizerType
 } from 'microsoft-cognitiveservices-speech-sdk';
-import { type AudioConfigImpl } from 'microsoft-cognitiveservices-speech-sdk/distrib/lib/src/sdk/Audio/AudioConfig';
+import { type AudioConfigImpl } from 'microsoft-cognitiveservices-speech-sdk/distrib/lib/src/sdk/Audio/AudioConfig.js';
 import { boolean, function_, parse, undefined_, union } from 'valibot';
 import createPromiseQueue from '../../Util/createPromiseQueue';
 import SpeechSDK from '../SpeechSDK';

--- a/packages/web-speech-cognitive-services/src/SpeechServices/SpeechToText/private/prepareAudioConfig.ts
+++ b/packages/web-speech-cognitive-services/src/SpeechServices/SpeechToText/private/prepareAudioConfig.ts
@@ -1,8 +1,8 @@
-import { AudioSourceEvent } from 'microsoft-cognitiveservices-speech-sdk/distrib/lib/src/common/AudioSourceEvents';
+import { AudioSourceEvent } from 'microsoft-cognitiveservices-speech-sdk/distrib/lib/src/common/AudioSourceEvents.js';
 import {
   type AudioConfig,
   type AudioConfigImpl
-} from 'microsoft-cognitiveservices-speech-sdk/distrib/lib/src/sdk/Audio/AudioConfig';
+} from 'microsoft-cognitiveservices-speech-sdk/distrib/lib/src/sdk/Audio/AudioConfig.js';
 import averageAmplitude from './averageAmplitude';
 
 export default function prepareAudioConfig(audioConfig: AudioConfig) {

--- a/packages/web-speech-cognitive-services/utils/speechRecognition/createQueuedArrayBufferAudioSource.js
+++ b/packages/web-speech-cognitive-services/utils/speechRecognition/createQueuedArrayBufferAudioSource.js
@@ -9,12 +9,12 @@ import {
   AudioStreamNodeAttachingEvent,
   AudioStreamNodeDetachedEvent
   // AudioStreamNodeErrorEvent,
-} from 'microsoft-cognitiveservices-speech-sdk/distrib/lib/src/common/AudioSourceEvents';
+} from 'microsoft-cognitiveservices-speech-sdk/distrib/lib/src/common/AudioSourceEvents.js';
 
-import { ChunkedArrayBufferStream } from 'microsoft-cognitiveservices-speech-sdk/distrib/lib/src/common/ChunkedArrayBufferStream';
-import { createNoDashGuid } from 'microsoft-cognitiveservices-speech-sdk/distrib/lib/src/common/Guid';
-import { Events } from 'microsoft-cognitiveservices-speech-sdk/distrib/lib/src/common/Events';
-import { EventSource } from 'microsoft-cognitiveservices-speech-sdk/distrib/lib/src/common/EventSource';
+import { ChunkedArrayBufferStream } from 'microsoft-cognitiveservices-speech-sdk/distrib/lib/src/common/ChunkedArrayBufferStream.js';
+import { createNoDashGuid } from 'microsoft-cognitiveservices-speech-sdk/distrib/lib/src/common/Guid.js';
+import { Events } from 'microsoft-cognitiveservices-speech-sdk/distrib/lib/src/common/Events.js';
+import { EventSource } from 'microsoft-cognitiveservices-speech-sdk/distrib/lib/src/common/EventSource.js';
 
 // This is copied from MicAudioSource, but instead of retrieving from MediaStream, we dump the ArrayBuffer directly.
 class QueuedArrayBufferAudioSource {


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Fixed

- Fixed import of Speech SDK with file extension to resolve build breaks with `create-react-app`, by [@compulim](https://github.com/compulim), in PR [#243](https://github.com/compulim/web-speech-cognitive-services/pull/243)

## Background

Without having file extension, importing a file would break when it is being built in `create-react-app`.

```
Creating an optimized production build...
Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
Failed to compile.

Module not found: Error: Can't resolve 'microsoft-cognitiveservices-speech-sdk/distrib/lib/src/common/AudioSourceEvents' in '/home/.../node_modules/web-speech-cognitive-services/dist'
Did you mean 'AudioSourceEvents.js'?
BREAKING CHANGE: The request 'microsoft-cognitiveservices-speech-sdk/distrib/lib/src/common/AudioSourceEvents' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
```

## Specific changes

> Please list each individual specific change in this pull request.

- Updated to include `.js` for file-based imports